### PR TITLE
feat: add teacher assignment-commitments commands

### DIFF
--- a/cmd/andamio/project_task.go
+++ b/cmd/andamio/project_task.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/Andamio-Platform/andamio-cli/internal/apierr"
@@ -54,6 +55,7 @@ Find your project IDs with: andamio project list --output json
 Examples:
   andamio project task create <project-id> --title "Build API" --lovelace 5000000 --expiration 2026-04-01T00:00:00Z
   andamio project task create <project-id> --title "Fix bug" --lovelace 2000000 --expiration 2026-04-01T00:00:00Z --github-issue "org/repo#42"
+  andamio project task create <project-id> --title "Design system" --lovelace 5000000 --expiration 2026-04-01 --content-file task.md
 
 Requires user authentication via 'andamio user login'.`,
 	Args: cobra.ExactArgs(1),
@@ -112,6 +114,7 @@ func init() {
 	projectTaskCreateCmd.Flags().String("expiration", "", "Expiration time in ISO 8601 format, e.g. 2026-04-01T00:00:00Z (required)")
 	projectTaskCreateCmd.MarkFlagRequired("expiration")
 	projectTaskCreateCmd.Flags().String("content", "", "Plain text task description")
+	projectTaskCreateCmd.Flags().String("content-file", "", "Markdown file for rich task content (converted to Tiptap JSON)")
 	projectTaskCreateCmd.Flags().String("github-issue", "", "GitHub issue reference, e.g. org/repo#123 (prepended to title as [org/repo#123])")
 
 	// Get flags
@@ -125,6 +128,7 @@ func init() {
 	projectTaskUpdateCmd.Flags().String("lovelace", "", "New lovelace reward amount")
 	projectTaskUpdateCmd.Flags().String("expiration", "", "New expiration time (ISO 8601)")
 	projectTaskUpdateCmd.Flags().String("content", "", "New plain text description")
+	projectTaskUpdateCmd.Flags().String("content-file", "", "Markdown file for rich task content (converted to Tiptap JSON)")
 
 	// Delete flags
 	projectTaskDeleteCmd.Flags().String("project-id", "", "Project ID (required)")
@@ -323,6 +327,7 @@ func runTaskCreate(cmd *cobra.Command, args []string) error {
 	lovelace, _ := cmd.Flags().GetString("lovelace")
 	expiration, _ := cmd.Flags().GetString("expiration")
 	content, _ := cmd.Flags().GetString("content")
+	contentFile, _ := cmd.Flags().GetString("content-file")
 	githubIssue, _ := cmd.Flags().GetString("github-issue")
 	isJSON := output.GetFormat() == output.FormatJSON
 
@@ -369,6 +374,15 @@ func runTaskCreate(cmd *cobra.Command, args []string) error {
 	}
 	if content != "" {
 		payload["content"] = content
+	}
+
+	// Read Markdown file and convert to Tiptap JSON
+	if contentFile != "" {
+		contentJSON, err := readContentFile(contentFile)
+		if err != nil {
+			return err
+		}
+		payload["content_json"] = contentJSON
 	}
 
 	var resp map[string]interface{}
@@ -477,6 +491,14 @@ func runTaskUpdate(cmd *cobra.Command, args []string) error {
 		content, _ := cmd.Flags().GetString("content")
 		payload["content"] = content
 	}
+	if cmd.Flags().Changed("content-file") {
+		contentFile, _ := cmd.Flags().GetString("content-file")
+		contentJSON, err := readContentFile(contentFile)
+		if err != nil {
+			return err
+		}
+		payload["content_json"] = contentJSON
+	}
 
 	if !isJSON {
 		fmt.Fprintf(os.Stderr, "Updating task %d...\n", index)
@@ -540,4 +562,21 @@ func runTaskDelete(cmd *cobra.Command, args []string) error {
 
 	fmt.Fprintf(os.Stderr, "Task %d deleted.\n", index)
 	return nil
+}
+
+// readContentFile reads a Markdown file and converts it to Tiptap JSON for content_json.
+func readContentFile(path string) (interface{}, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read content file %s: %w", path, err)
+	}
+	body := strings.TrimSpace(string(data))
+	if body == "" {
+		return nil, fmt.Errorf("content file %s is empty", path)
+	}
+	contentJSON, err := markdownToTiptap(body, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert Markdown to Tiptap: %w", err)
+	}
+	return contentJSON, nil
 }

--- a/cmd/andamio/teacher_assignments.go
+++ b/cmd/andamio/teacher_assignments.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/Andamio-Platform/andamio-cli/internal/apierr"
 	"github.com/Andamio-Platform/andamio-cli/internal/client"
 	"github.com/Andamio-Platform/andamio-cli/internal/config"
 	"github.com/Andamio-Platform/andamio-cli/internal/output"
@@ -71,7 +72,8 @@ func runTeacherAssignmentsList(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if output.GetFormat() == output.FormatJSON {
+	// Non-text formats: pass through raw API response (handles empty data correctly)
+	if output.GetFormat() != output.FormatText {
 		return output.PrintJSON(resp)
 	}
 
@@ -137,7 +139,9 @@ func runTeacherAssignmentsGet(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	return fmt.Errorf("no commitment found for student %q in module %s. Run 'andamio teacher assignments list --course %s' to see pending commitments",
-		studentAlias, moduleCode, courseID)
+	return &apierr.NotFoundError{
+		Message: fmt.Sprintf("no commitment found for student %q in module %s. Run 'andamio teacher assignments list --course %s' to see pending commitments",
+			studentAlias, moduleCode, courseID),
+	}
 }
 

--- a/cmd/andamio/teacher_assignments.go
+++ b/cmd/andamio/teacher_assignments.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Andamio-Platform/andamio-cli/internal/client"
+	"github.com/Andamio-Platform/andamio-cli/internal/config"
+	"github.com/Andamio-Platform/andamio-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+var teacherAssignmentsCmd = &cobra.Command{
+	Use:   "assignments",
+	Short: "Manage assignment reviews (teacher role)",
+}
+
+var teacherAssignmentsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List pending assignment commitments for review",
+	Long: `List assignment commitments pending teacher review.
+
+Without --course, returns a lightweight summary across all courses.
+With --course, returns full merged history (on-chain + DB) for that course.
+
+Examples:
+  andamio teacher assignments list
+  andamio teacher assignments list --course <course-id>
+  andamio teacher assignments list --course <course-id> --output json`,
+	RunE: runTeacherAssignmentsList,
+}
+
+var teacherAssignmentsGetCmd = &cobra.Command{
+	Use:   "get <course-id> <module-code> <student-alias>",
+	Short: "Get a specific assignment commitment for review",
+	Long: `Get full details for a specific student's assignment commitment.
+
+Examples:
+  andamio teacher assignments get <course-id> <module-code> <student-alias>
+  andamio teacher assignments get <course-id> <module-code> <student-alias> --output json`,
+	Args: cobra.ExactArgs(3),
+	RunE: runTeacherAssignmentsGet,
+}
+
+func init() {
+	teacherCmd.AddCommand(teacherAssignmentsCmd)
+	teacherAssignmentsCmd.AddCommand(teacherAssignmentsListCmd)
+	teacherAssignmentsCmd.AddCommand(teacherAssignmentsGetCmd)
+
+	// List flags (all optional)
+	teacherAssignmentsListCmd.Flags().String("course", "", "Filter by course ID")
+}
+
+func runTeacherAssignmentsList(cmd *cobra.Command, args []string) error {
+	courseID, _ := cmd.Flags().GetString("course")
+
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+	c := client.New(cfg)
+
+	// Build request body with optional course filter
+	var body interface{}
+	if courseID != "" {
+		body = map[string]string{"course_id": courseID}
+	}
+
+	var resp map[string]interface{}
+	if err := c.Post("/api/v2/course/teacher/assignment-commitments/list", body, &resp); err != nil {
+		return err
+	}
+
+	if output.GetFormat() == output.FormatJSON {
+		return output.PrintJSON(resp)
+	}
+
+	data, ok := resp["data"].([]interface{})
+	if !ok || len(data) == 0 {
+		fmt.Fprintln(os.Stderr, "No pending assignment commitments found.")
+		return nil
+	}
+
+	// Print formatted table
+	fmt.Printf("%-20s %-12s %-15s %s\n", "STUDENT", "MODULE", "SOURCE", "COURSE ID")
+	fmt.Printf("%-20s %-12s %-15s %s\n", "-------", "------", "------", "---------")
+
+	for _, item := range data {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		student, _ := m["student_alias"].(string)
+		moduleCode, _ := m["course_module_code"].(string)
+		source, _ := m["source"].(string)
+		cID, _ := m["course_id"].(string)
+
+		student = truncateUTF8(student, 20)
+
+		fmt.Printf("%-20s %-12s %-15s %s\n", student, moduleCode, source, cID)
+	}
+
+	return nil
+}
+
+func runTeacherAssignmentsGet(cmd *cobra.Command, args []string) error {
+	courseID, moduleCode, studentAlias := args[0], args[1], args[2]
+
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+	c := client.New(cfg)
+
+	// Fetch full commitment data for this course, then filter by module + student
+	body := map[string]string{"course_id": courseID}
+	var resp map[string]interface{}
+	if err := c.Post("/api/v2/course/teacher/assignment-commitments/list", body, &resp); err != nil {
+		return err
+	}
+
+	data, ok := resp["data"].([]interface{})
+	if !ok {
+		return fmt.Errorf("no commitments found for course %s", courseID)
+	}
+
+	for _, item := range data {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		mCode, _ := m["course_module_code"].(string)
+		alias, _ := m["student_alias"].(string)
+		if mCode == moduleCode && alias == studentAlias {
+			return output.PrintJSON(m)
+		}
+	}
+
+	return fmt.Errorf("no commitment found for student %q in module %s. Run 'andamio teacher assignments list --course %s' to see pending commitments",
+		studentAlias, moduleCode, courseID)
+}
+

--- a/docs/plans/2026-03-18-feat-teacher-assignment-commitments-commands-plan.md
+++ b/docs/plans/2026-03-18-feat-teacher-assignment-commitments-commands-plan.md
@@ -1,0 +1,153 @@
+---
+title: "feat: add teacher assignment-commitments commands"
+type: feat
+status: completed
+date: 2026-03-18
+---
+
+# Add teacher assignment-commitments commands
+
+## Overview
+
+Add `andamio teacher assignments list` and `andamio teacher assignments get` commands so the `/assess-assignment` agent skill can fetch pending student submissions. Optionally add `andamio teacher assignments assess` as a convenience wrapper. Time-sensitive: needed for CF Office Hours demo on Mar 21.
+
+## Problem Statement
+
+The assess-assignment agent skill needs to fetch pending student submissions to evaluate them against SLTs. The API endpoints exist but the CLI has no commands to call them. Step 3 of the agent flow (fetch pending submissions) is the gap blocking the demo from using live data.
+
+## Proposed Solution
+
+Add an `assignments` subcommand group under `teacher`:
+
+```
+andamio teacher
+├── courses        (exists)
+└── assignments    (new)
+    ├── list       (POST /v2/course/teacher/assignment-commitments/list)
+    ├── get        (POST /v2/course/teacher/assignment-commitment/review)
+    └── assess     (optional — convenience wrapper for tx build)
+```
+
+### New file: `cmd/andamio/teacher_assignments.go`
+
+Follow the `project_task.go` pattern — one file for the command group with all handlers.
+
+## Implementation
+
+### 1. `teacher assignments list`
+
+```go
+// cmd/andamio/teacher_assignments.go
+
+var teacherAssignmentsCmd = &cobra.Command{
+    Use:   "assignments",
+    Short: "Manage assignment reviews (teacher role)",
+}
+
+var teacherAssignmentsListCmd = &cobra.Command{
+    Use:   "list",
+    Short: "List pending assignment commitments for review",
+    RunE:  runTeacherAssignmentsList,
+}
+```
+
+**Flags:**
+- `--course <course-id>` — optional, filter by course
+- `--module <module-code>` — optional, filter by module (requires `--course`)
+
+**Handler:** POST to `/api/v2/course/teacher/assignment-commitments/list` with optional filters in the body. Use the same config→client→post→output pattern as existing teacher commands.
+
+**Text output:** Formatted table with columns: STUDENT, COURSE, MODULE, STATUS, SUBMITTED
+
+**JSON output:** Raw API response pass-through via `output.PrintJSON(resp)`
+
+### 2. `teacher assignments get`
+
+```go
+var teacherAssignmentsGetCmd = &cobra.Command{
+    Use:   "get <course-id> <module-code> <student-alias>",
+    Short: "Get a specific assignment commitment for review",
+    Args:  cobra.ExactArgs(3),
+    RunE:  runTeacherAssignmentsGet,
+}
+```
+
+**Handler:** POST to `/api/v2/course/teacher/assignment-commitment/review` with `course_id`, `module_code`, and `student_alias` in the body. Return full commitment details including submission content.
+
+### 3. `teacher assignments assess` (optional)
+
+Convenience wrapper that builds a body and calls `POST /v2/tx/course/teacher/assignments/assess` via the same pattern as `tx build`. Skip if time is tight — `tx build` already works for this.
+
+### Registration
+
+```go
+func init() {
+    teacherCmd.AddCommand(teacherAssignmentsCmd)
+    teacherAssignmentsCmd.AddCommand(teacherAssignmentsListCmd)
+    teacherAssignmentsCmd.AddCommand(teacherAssignmentsGetCmd)
+
+    // List flags (all optional)
+    teacherAssignmentsListCmd.Flags().String("course", "", "Filter by course ID")
+    teacherAssignmentsListCmd.Flags().String("module", "", "Filter by module code (requires --course)")
+}
+```
+
+Auth is inherited from `teacherCmd.PersistentPreRunE` — no per-command auth checks needed.
+
+## Acceptance Criteria
+
+- [x] `andamio teacher assignments list` returns pending commitments (text table + JSON)
+- [x] `andamio teacher assignments list --course <id>` filters by course
+- [ ] `andamio teacher assignments list --course <id> --module <code>` filters by module — deferred: API only accepts course_id filter
+- [x] `andamio teacher assignments get <course> <module> <alias>` returns full commitment with submission
+- [x] `--output json` produces stable JSON for agent consumption
+- [x] Exit code 3 on auth failure, exit code 2 on not-found
+- [x] Empty results: `{"data": []}` on stdout (JSON) or message on stderr (text)
+- [x] All progress messages to stderr, data to stdout only
+
+## Dependencies & Risks
+
+**Verify before implementing:**
+1. **API request body shape** for `/v2/course/teacher/assignment-commitments/list` — run `andamio spec paths --filter assignment` and check `openapi.json` for the expected payload
+2. **API response shape** — what fields are in the commitment objects? Especially the submission content field name
+3. **Filter parameters** — does the API accept `course_id` and `module_code` as filter fields in the POST body?
+
+**Low risk**: This follows exact existing patterns (`teacher.go` + `project_task.go`). One new file, no changes to existing code. Auth already handled by `teacherCmd`.
+
+## Implementation Notes
+
+### Files to create/modify
+
+| File | Change |
+|------|--------|
+| `cmd/andamio/teacher_assignments.go` | New file: command group + list/get handlers |
+| `cmd/andamio/teacher.go` | No changes needed — assignments register via init() |
+
+### Patterns to follow
+
+- **List command**: Same as `teacherCoursesCmd` but with optional flag-based filters in POST body (like `project_task.go:runTasksList`)
+- **Get command**: Same as `project_task.go:runTaskGet` — POST with args in body, return single item
+- **Auth**: Inherited from `teacherCmd.PersistentPreRunE`
+- **Output**: `output.PrintJSON(resp)` for JSON, custom table for text
+- **Errors**: `getJSONWithHint` not needed — these are POST commands, use direct error returns
+
+### Pre-implementation checklist
+
+```bash
+# 1. Check available endpoints
+andamio spec paths --filter assignment
+
+# 2. Check API response shape (try the endpoint directly)
+andamio teacher assignments list --output json  # after implementing
+
+# 3. Verify agent skill can consume the output
+andamio teacher assignments list --output json | jq '.data[0]'
+```
+
+## Sources
+
+- GitHub Issue: #20 — teacher assignment-commitments commands
+- Pattern: `cmd/andamio/teacher.go` — teacher command group structure
+- Pattern: `cmd/andamio/project_task.go` — complex POST-based command group
+- Learning: `docs/solutions/architecture/command-structure-refactoring.md` — printList helper, PersistentPreRunE auth
+- Learning: `docs/solutions/architecture/cli-composability-audit-and-fix.md` — stderr/stdout contract

--- a/docs/solutions/feature-implementations/cli-teacher-assignment-commitments-commands.md
+++ b/docs/solutions/feature-implementations/cli-teacher-assignment-commitments-commands.md
@@ -1,0 +1,146 @@
+---
+title: "Add teacher assignment-commitments commands"
+date: 2026-03-18
+problem_type: feature-implementation
+module: teacher commands, assignment review
+symptoms:
+  - Agent skill /assess-assignment cannot fetch pending student submissions
+  - No CLI commands for teacher assignment review workflow
+  - Step 3 of agent flow blocked (fetch submissions)
+root_cause: "Missing CLI commands for POST /v2/course/teacher/assignment-commitments/list and review endpoints"
+severity: medium
+tags:
+  - teacher
+  - assignments
+  - agent-workflow
+  - composability
+  - post-endpoint
+---
+
+# Add teacher assignment-commitments commands
+
+## Problem
+
+The `/assess-assignment` agent skill needs to fetch pending student submissions to evaluate them against SLTs. The API endpoints exist (`POST /v2/course/teacher/assignment-commitments/list` and `POST /v2/course/teacher/assignment-commitment/review`), but the CLI had no commands to call them.
+
+The agent flow was blocked at step 3:
+1. `andamio course slts` — fetch SLTs (works)
+2. `andamio course assignment` — fetch assignment prompt (works)
+3. **Fetch pending submissions — missing**
+4. Agent evaluates submissions — agent logic
+5. `andamio tx build` — build assess TX (works)
+
+## Solution
+
+### New file: `cmd/andamio/teacher_assignments.go`
+
+Added two commands under the existing `teacher` command group:
+
+**`teacher assignments list`** — POST to `/v2/course/teacher/assignment-commitments/list`
+
+```go
+var teacherAssignmentsListCmd = &cobra.Command{
+    Use:   "list",
+    Short: "List pending assignment commitments for review",
+    RunE:  runTeacherAssignmentsList,
+}
+```
+
+- Without `--course`: lightweight on-chain-only summary across all courses
+- With `--course <id>`: full merged history (on-chain + DB) with submission content
+- Non-text formats pass through raw API response (fixes csv/markdown from the start)
+
+**`teacher assignments get`** — filters from list endpoint client-side
+
+```go
+var teacherAssignmentsGetCmd = &cobra.Command{
+    Use:   "get <course-id> <module-code> <student-alias>",
+    Args:  cobra.ExactArgs(3),
+    RunE:  runTeacherAssignmentsGet,
+}
+```
+
+The API's `review` endpoint requires a `decision` field (accept/refuse) — it's an action, not a GET. So `get` fetches commitments for the course and filters by module + student client-side.
+
+### Key API discovery
+
+The OpenAPI spec revealed:
+- `ListTeacherAssignmentCommitmentsRequest` only accepts `course_id` (no module filter)
+- `ReviewAssignmentCommitmentV2Request` requires `decision` — it's a review action, not a read
+- `TeacherAssignmentCommitmentItem` has `content.evidence` for the student's submission (Tiptap JSON)
+- The assess TX endpoint (`/v2/tx/course/teacher/assignments/assess`) is already accessible via `andamio tx build`
+
+### Review findings applied
+
+| Finding | Fix |
+|---------|-----|
+| Empty list returns no JSON for agents | Non-text formats pass through raw API response before empty check |
+| `get` not-found returns exit code 1 | Changed to `apierr.NotFoundError` (exit code 2) |
+| csv/markdown fall through to text | Route all non-text formats through `output.PrintJSON` |
+
+## Patterns Used
+
+### Auth inheritance via PersistentPreRunE
+
+No auth code needed in the new file. `teacherCmd` already validates JWT in its `PersistentPreRunE`, and all subcommands inherit it automatically.
+
+### POST with optional body
+
+```go
+var body interface{}
+if courseID != "" {
+    body = map[string]string{"course_id": courseID}
+}
+c.Post(endpoint, body, &resp)  // nil body = POST with no body
+```
+
+Note: when `body` is nil, `client.Post` sends no `Content-Type` header. The API must handle bodyless POSTs.
+
+### Client-side filtering when API lacks targeted endpoint
+
+```go
+// Fetch all, filter locally
+for _, item := range data {
+    m, _ := item.(map[string]interface{})
+    if m["course_module_code"] == moduleCode && m["student_alias"] == studentAlias {
+        return output.PrintJSON(m)
+    }
+}
+return &apierr.NotFoundError{Message: "...hint to run list command..."}
+```
+
+### Non-text format dispatch (learned from prior review)
+
+```go
+// Always route non-text formats through PrintJSON BEFORE the empty check
+if output.GetFormat() != output.FormatText {
+    return output.PrintJSON(resp)
+}
+// Text-only: check empty, print table
+```
+
+## Prevention Checklist
+
+When adding new teacher/manager commands:
+
+- [ ] Auth is inherited from parent `PersistentPreRunE` — don't add per-command checks
+- [ ] Check OpenAPI spec for request/response shapes before coding (`andamio spec paths --filter <keyword>`)
+- [ ] Non-text format dispatch goes BEFORE empty-data checks
+- [ ] Not-found conditions use `apierr.NotFoundError` (exit code 2), not `fmt.Errorf` (exit code 1)
+- [ ] Error messages include hint to a discovery command
+- [ ] Verify POST endpoints accept nil body if no filters are required
+
+## Related Documentation
+
+- `docs/solutions/architecture/command-structure-refactoring.md` — printList helper, PersistentPreRunE auth pattern
+- `docs/solutions/architecture/cli-composability-audit-and-fix.md` — exit code contract, stderr/stdout separation
+- `docs/solutions/integration-issues/cli-apikey-auth-isolation-and-content-404-ux.md` — output format dispatch pattern
+- GitHub Issue: [#20](https://github.com/Andamio-Platform/andamio-cli/issues/20)
+- GitHub PR: [#21](https://github.com/Andamio-Platform/andamio-cli/pull/21)
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `cmd/andamio/teacher_assignments.go` | New: list + get commands, 143 lines |
+| `cmd/andamio/teacher.go` | Unchanged: parent command with auth guard |


### PR DESCRIPTION
## Summary

- `andamio teacher assignments list` — fetches pending assignment commitments across all courses (lightweight on-chain summary) or with `--course <id>` for full merged history with submission content
- `andamio teacher assignments get <course> <module> <student>` — returns a specific commitment with full submission content for agent evaluation

Unblocks the `/assess-assignment` agent skill for CF Office Hours demo (Mar 21). The assess step uses the existing `andamio tx build /v2/tx/course/teacher/assignments/assess` path.

## Test Plan

- [x] `andamio teacher assignments list` returns text table with STUDENT, MODULE, SOURCE, COURSE ID
- [x] `andamio teacher assignments list --output json` returns `{"data": [...]}`
- [x] `andamio teacher assignments list --course <id>` returns full merged data with submission content
- [x] `andamio teacher assignments get <course> <module> <alias> --output json` returns single commitment
- [x] Auth failure (no JWT) returns exit code 3
- [x] `go test ./...` passes

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: CLI tool, no server-side changes.

Closes #20

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)