### PR TITLE
feat: add --token flag to project task create/update

### DIFF
--- a/cmd/andamio/project_task.go
+++ b/cmd/andamio/project_task.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/hex"
 	"fmt"
 	"os"
 	"strconv"
@@ -343,6 +344,12 @@ func parseTokenFlags(values []string) ([]TaskToken, error) {
 
 		if policyID == "" {
 			return nil, fmt.Errorf("invalid --token format %q: policy_id cannot be empty", v)
+		}
+		if len(policyID) != 56 {
+			return nil, fmt.Errorf("invalid --token policy_id %q: must be 56 hex characters", policyID)
+		}
+		if _, err := hex.DecodeString(policyID); err != nil {
+			return nil, fmt.Errorf("invalid --token policy_id %q: must be hexadecimal", policyID)
 		}
 		if quantity == "" {
 			return nil, fmt.Errorf("invalid --token format %q: quantity cannot be empty", v)

--- a/cmd/andamio/project_task.go
+++ b/cmd/andamio/project_task.go
@@ -56,6 +56,7 @@ Examples:
   andamio project task create <project-id> --title "Build API" --lovelace 5000000 --expiration 2026-04-01T00:00:00Z
   andamio project task create <project-id> --title "Fix bug" --lovelace 2000000 --expiration 2026-04-01T00:00:00Z --github-issue "org/repo#42"
   andamio project task create <project-id> --title "Design system" --lovelace 5000000 --expiration 2026-04-01 --content-file task.md
+  andamio project task create <project-id> --title "Earn XP" --lovelace 5000000 --expiration 2026-04-01 --token "policyid...,XP,50"
 
 Requires user authentication via 'andamio user login'.`,
 	Args: cobra.ExactArgs(1),
@@ -116,6 +117,7 @@ func init() {
 	projectTaskCreateCmd.Flags().String("content", "", "Plain text task description")
 	projectTaskCreateCmd.Flags().String("content-file", "", "Markdown file for rich task content (converted to Tiptap JSON)")
 	projectTaskCreateCmd.Flags().String("github-issue", "", "GitHub issue reference, e.g. org/repo#123 (prepended to title as [org/repo#123])")
+	projectTaskCreateCmd.Flags().StringArray("token", nil, `Native asset token (repeatable, format: "policy_id,asset_name,quantity")`)
 
 	// Get flags
 	projectTaskGetCmd.Flags().String("project-id", "", "Project ID (required)")
@@ -129,6 +131,7 @@ func init() {
 	projectTaskUpdateCmd.Flags().String("expiration", "", "New expiration time (ISO 8601)")
 	projectTaskUpdateCmd.Flags().String("content", "", "New plain text description")
 	projectTaskUpdateCmd.Flags().String("content-file", "", "Markdown file for rich task content (converted to Tiptap JSON)")
+	projectTaskUpdateCmd.Flags().StringArray("token", nil, `Native asset token (repeatable, format: "policy_id,asset_name,quantity")`)
 
 	// Delete flags
 	projectTaskDeleteCmd.Flags().String("project-id", "", "Project ID (required)")
@@ -322,6 +325,52 @@ func validateLovelace(lovelace string) error {
 	return nil
 }
 
+// parseTokenFlags parses --token flag values into TaskToken structs.
+// Each value must be "policy_id,asset_name,quantity". Empty asset_name is allowed.
+func parseTokenFlags(values []string) ([]TaskToken, error) {
+	tokens := make([]TaskToken, 0, len(values))
+	seen := make(map[string]bool)
+
+	for _, v := range values {
+		parts := strings.SplitN(v, ",", 3)
+		if len(parts) != 3 {
+			return nil, fmt.Errorf("invalid --token format %q: expected \"policy_id,asset_name,quantity\"\n  Example: --token \"722c475bebb10...,XP,50\"", v)
+		}
+
+		policyID := strings.TrimSpace(parts[0])
+		assetName := strings.TrimSpace(parts[1])
+		quantity := strings.TrimSpace(parts[2])
+
+		if policyID == "" {
+			return nil, fmt.Errorf("invalid --token format %q: policy_id cannot be empty", v)
+		}
+		if quantity == "" {
+			return nil, fmt.Errorf("invalid --token format %q: quantity cannot be empty", v)
+		}
+
+		// Validate quantity is a non-negative integer
+		val, err := strconv.ParseInt(quantity, 10, 64)
+		if err != nil || val < 0 {
+			return nil, fmt.Errorf("invalid --token quantity %q: must be a non-negative integer", quantity)
+		}
+
+		// Check for duplicates
+		key := policyID + ":" + assetName
+		if seen[key] {
+			return nil, fmt.Errorf("duplicate token: policy_id %q + asset_name %q specified twice", policyID, assetName)
+		}
+		seen[key] = true
+
+		tokens = append(tokens, TaskToken{
+			PolicyID:  policyID,
+			AssetName: assetName,
+			Quantity:  quantity,
+		})
+	}
+
+	return tokens, nil
+}
+
 func runTaskCreate(cmd *cobra.Command, args []string) error {
 	title, _ := cmd.Flags().GetString("title")
 	lovelace, _ := cmd.Flags().GetString("lovelace")
@@ -383,6 +432,16 @@ func runTaskCreate(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		payload["content_json"] = contentJSON
+	}
+
+	// Parse and add token rewards
+	tokenStrs, _ := cmd.Flags().GetStringArray("token")
+	if len(tokenStrs) > 0 {
+		tokens, err := parseTokenFlags(tokenStrs)
+		if err != nil {
+			return err
+		}
+		payload["tokens"] = tokens
 	}
 
 	var resp map[string]interface{}
@@ -498,6 +557,14 @@ func runTaskUpdate(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		payload["content_json"] = contentJSON
+	}
+	if cmd.Flags().Changed("token") {
+		tokenStrs, _ := cmd.Flags().GetStringArray("token")
+		tokens, err := parseTokenFlags(tokenStrs)
+		if err != nil {
+			return err
+		}
+		payload["tokens"] = tokens
 	}
 
 	if !isJSON {

--- a/cmd/andamio/project_task_test.go
+++ b/cmd/andamio/project_task_test.go
@@ -1,7 +1,14 @@
 package main
 
 import (
+	"strings"
 	"testing"
+)
+
+// Valid 56-char hex policy IDs for tests
+const (
+	testPolicyA = "722c475bebb106799b109fc95301c9b796e1a37b6afc601359d54a04"
+	testPolicyB = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8"
 )
 
 func TestParseTokenFlags(t *testing.T) {
@@ -13,31 +20,31 @@ func TestParseTokenFlags(t *testing.T) {
 	}{
 		{
 			name:  "single token",
-			input: []string{"abc123,XP,50"},
-			want:  []TaskToken{{PolicyID: "abc123", AssetName: "XP", Quantity: "50"}},
+			input: []string{testPolicyA + ",XP,50"},
+			want:  []TaskToken{{PolicyID: testPolicyA, AssetName: "XP", Quantity: "50"}},
 		},
 		{
 			name:  "multiple tokens",
-			input: []string{"abc123,XP,50", "def456,RewardToken,100"},
+			input: []string{testPolicyA + ",XP,50", testPolicyB + ",RewardToken,100"},
 			want: []TaskToken{
-				{PolicyID: "abc123", AssetName: "XP", Quantity: "50"},
-				{PolicyID: "def456", AssetName: "RewardToken", Quantity: "100"},
+				{PolicyID: testPolicyA, AssetName: "XP", Quantity: "50"},
+				{PolicyID: testPolicyB, AssetName: "RewardToken", Quantity: "100"},
 			},
 		},
 		{
 			name:  "empty asset name allowed",
-			input: []string{"abc123,,50"},
-			want:  []TaskToken{{PolicyID: "abc123", AssetName: "", Quantity: "50"}},
+			input: []string{testPolicyA + ",,50"},
+			want:  []TaskToken{{PolicyID: testPolicyA, AssetName: "", Quantity: "50"}},
 		},
 		{
 			name:  "whitespace trimmed",
-			input: []string{"abc123 , XP , 50"},
-			want:  []TaskToken{{PolicyID: "abc123", AssetName: "XP", Quantity: "50"}},
+			input: []string{testPolicyA + " , XP , 50"},
+			want:  []TaskToken{{PolicyID: testPolicyA, AssetName: "XP", Quantity: "50"}},
 		},
 		{
 			name:    "wrong field count - too few",
-			input:   []string{"abc123,XP"},
-			wantErr: `invalid --token format "abc123,XP"`,
+			input:   []string{testPolicyA + ",XP"},
+			wantErr: `invalid --token format`,
 		},
 		{
 			name:    "single value no commas",
@@ -50,29 +57,38 @@ func TestParseTokenFlags(t *testing.T) {
 			wantErr: "policy_id cannot be empty",
 		},
 		{
+			name:    "policy_id wrong length",
+			input:   []string{"abc123,XP,50"},
+			wantErr: "must be 56 hex characters",
+		},
+		{
+			name:    "policy_id not hex",
+			input:   []string{"zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz,XP,50"},
+			wantErr: "must be hexadecimal",
+		},
+		{
 			name:    "empty quantity",
-			input:   []string{"abc123,XP,"},
+			input:   []string{testPolicyA + ",XP,"},
 			wantErr: "quantity cannot be empty",
 		},
 		{
 			name:    "non-numeric quantity",
-			input:   []string{"abc123,XP,abc"},
+			input:   []string{testPolicyA + ",XP,abc"},
 			wantErr: `invalid --token quantity "abc"`,
 		},
 		{
 			name:    "negative quantity",
-			input:   []string{"abc123,XP,-5"},
+			input:   []string{testPolicyA + ",XP,-5"},
 			wantErr: `invalid --token quantity "-5"`,
 		},
 		{
 			name:    "duplicate token",
-			input:   []string{"abc123,XP,50", "abc123,XP,100"},
+			input:   []string{testPolicyA + ",XP,50", testPolicyA + ",XP,100"},
 			wantErr: "duplicate token",
 		},
 		{
-			name:  "extra commas preserved in quantity field via SplitN",
-			input: []string{"abc123,XP,50,extra"},
-			// SplitN(v, ",", 3) means "50,extra" is the quantity field, which fails validation
+			name:    "extra commas preserved in quantity field via SplitN",
+			input:   []string{testPolicyA + ",XP,50,extra"},
 			wantErr: `invalid --token quantity "50,extra"`,
 		},
 	}
@@ -84,7 +100,7 @@ func TestParseTokenFlags(t *testing.T) {
 				if err == nil {
 					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
 				}
-				if !contains(err.Error(), tt.wantErr) {
+				if !strings.Contains(err.Error(), tt.wantErr) {
 					t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
 				}
 				return
@@ -102,17 +118,4 @@ func TestParseTokenFlags(t *testing.T) {
 			}
 		})
 	}
-}
-
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && searchString(s, substr)
-}
-
-func searchString(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }

--- a/cmd/andamio/project_task_test.go
+++ b/cmd/andamio/project_task_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestParseTokenFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []string
+		want    []TaskToken
+		wantErr string
+	}{
+		{
+			name:  "single token",
+			input: []string{"abc123,XP,50"},
+			want:  []TaskToken{{PolicyID: "abc123", AssetName: "XP", Quantity: "50"}},
+		},
+		{
+			name:  "multiple tokens",
+			input: []string{"abc123,XP,50", "def456,RewardToken,100"},
+			want: []TaskToken{
+				{PolicyID: "abc123", AssetName: "XP", Quantity: "50"},
+				{PolicyID: "def456", AssetName: "RewardToken", Quantity: "100"},
+			},
+		},
+		{
+			name:  "empty asset name allowed",
+			input: []string{"abc123,,50"},
+			want:  []TaskToken{{PolicyID: "abc123", AssetName: "", Quantity: "50"}},
+		},
+		{
+			name:  "whitespace trimmed",
+			input: []string{"abc123 , XP , 50"},
+			want:  []TaskToken{{PolicyID: "abc123", AssetName: "XP", Quantity: "50"}},
+		},
+		{
+			name:    "wrong field count - too few",
+			input:   []string{"abc123,XP"},
+			wantErr: `invalid --token format "abc123,XP"`,
+		},
+		{
+			name:    "single value no commas",
+			input:   []string{"bad"},
+			wantErr: `invalid --token format "bad"`,
+		},
+		{
+			name:    "empty policy_id",
+			input:   []string{",XP,50"},
+			wantErr: "policy_id cannot be empty",
+		},
+		{
+			name:    "empty quantity",
+			input:   []string{"abc123,XP,"},
+			wantErr: "quantity cannot be empty",
+		},
+		{
+			name:    "non-numeric quantity",
+			input:   []string{"abc123,XP,abc"},
+			wantErr: `invalid --token quantity "abc"`,
+		},
+		{
+			name:    "negative quantity",
+			input:   []string{"abc123,XP,-5"},
+			wantErr: `invalid --token quantity "-5"`,
+		},
+		{
+			name:    "duplicate token",
+			input:   []string{"abc123,XP,50", "abc123,XP,100"},
+			wantErr: "duplicate token",
+		},
+		{
+			name:  "extra commas preserved in quantity field via SplitN",
+			input: []string{"abc123,XP,50,extra"},
+			// SplitN(v, ",", 3) means "50,extra" is the quantity field, which fails validation
+			wantErr: `invalid --token quantity "50,extra"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseTokenFlags(tt.input)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d tokens, want %d", len(got), len(tt.want))
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("token[%d] = %+v, want %+v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/docs/plans/2026-03-20-feat-add-token-flag-to-task-create-update-plan.md
+++ b/docs/plans/2026-03-20-feat-add-token-flag-to-task-create-update-plan.md
@@ -1,0 +1,205 @@
+---
+title: "Add --token flag to project task create and update"
+type: feat
+status: completed
+date: 2026-03-20
+origin: docs/brainstorms/2026-03-18-project-task-management-brainstorm.md
+---
+
+# Add --token flag to project task create and update
+
+## Overview
+
+`andamio project task create` cannot assign native Cardano assets (e.g. XP tokens) to a task. The API and task import already support tokens — the CLI create/update commands just need the flag wired up.
+
+## Problem Statement / Motivation
+
+Creating XP tasks via CLI requires native asset assignment. Current workaround is task import with Markdown files, but inline `task create` and `task update` should support the same features. Discovered during CF demo prep (Mar 20).
+
+## Proposed Solution
+
+Add a repeatable `--token` flag to both `project task create` and `project task update`.
+
+**Usage:**
+
+```bash
+# Single token
+andamio project task create <project-id> \
+  --title "Build a dApp" \
+  --lovelace 5000000 \
+  --expiration 2026-06-01 \
+  --token "722c475bebb106799b109fc95301c9b796e1a37b6afc601359d54a04,XP,50"
+
+# Multiple tokens
+andamio project task create <project-id> \
+  --title "Complete milestone" \
+  --lovelace 5000000 \
+  --expiration 2026-06-01 \
+  --token "abc123...,XP,50" \
+  --token "def456...,RewardToken,100"
+
+# Update: add tokens to existing task
+andamio project task update 3 --project-id <id> \
+  --token "abc123...,XP,50"
+```
+
+**Format:** `--token "policy_id,asset_name,quantity"` — comma-separated triple, repeatable.
+
+## Technical Approach
+
+### File to modify
+
+`cmd/andamio/project_task.go` — single file change.
+
+### Existing patterns to follow
+
+| Pattern | Source | Reference |
+|---------|--------|-----------|
+| `TaskToken` struct | `project_task_import.go:53-57` | Reuse directly (same package) |
+| `StringArray` repeatable flag | `tx_submit.go:36` (`--submit-header`) | Use `StringArray` not `StringSlice` |
+| Token payload inclusion | `project_task_import.go:249-251` | `payload["tokens"] = tokens` |
+| Conditional update field | `project_task.go:474-501` | `cmd.Flags().Changed("token")` guard |
+
+### Implementation steps
+
+#### 1. Register `--token` flag in `init()` (~line 115)
+
+Add to both `projectTaskCreateCmd` and `projectTaskUpdateCmd`:
+
+```go
+projectTaskCreateCmd.Flags().StringArray("token", nil,
+    `Native asset token (repeatable, format: "policy_id,asset_name,quantity")`)
+```
+
+```go
+projectTaskUpdateCmd.Flags().StringArray("token", nil,
+    `Native asset token (repeatable, format: "policy_id,asset_name,quantity")`)
+```
+
+#### 2. Add `parseTokenFlags` helper function
+
+Parse `[]string` from the flag into `[]TaskToken`. For each value:
+
+1. Split on `,` — expect exactly 3 fields
+2. `strings.TrimSpace()` each field (users will add spaces after commas)
+3. Validate: policy_id non-empty, quantity is a valid non-negative integer string
+4. Allow empty asset_name (valid for Cardano policy-only tokens: `"policy_id,,quantity"`)
+5. Reject duplicate policy_id + asset_name combinations
+6. Return `[]TaskToken` or error with clear message showing expected format
+
+#### 3. Add tokens to create payload (~line 386)
+
+After the existing `content_json` block in `runTaskCreate`:
+
+```go
+tokenStrs, _ := cmd.Flags().GetStringArray("token")
+if len(tokenStrs) > 0 {
+    tokens, err := parseTokenFlags(tokenStrs)
+    if err != nil {
+        return err
+    }
+    payload["tokens"] = tokens
+}
+```
+
+#### 4. Add tokens to update payload (~line 501)
+
+Using the existing `Changed()` guard pattern in `runTaskUpdate`:
+
+```go
+if cmd.Flags().Changed("token") {
+    tokenStrs, _ := cmd.Flags().GetStringArray("token")
+    tokens, err := parseTokenFlags(tokenStrs)
+    if err != nil {
+        return err
+    }
+    payload["tokens"] = tokens
+}
+```
+
+## Design Decisions
+
+### Delimiter: comma
+
+Comma-separated triple (`policy_id,asset_name,quantity`). Policy IDs are 56-char hex, asset names are hex-encoded, quantities are integers — none contain commas. Matches the format specified in the issue.
+
+### Flag type: `StringArray` (not `StringSlice`)
+
+`StringArray` treats each `--token value` as one element without comma-splitting the value itself. This is critical since the value already contains commas as delimiters. Matches the established pattern from `--submit-header` in `tx_submit.go`.
+
+### Update semantics: replace (not append)
+
+When `--token` is provided on update, it replaces the entire token array. This is consistent with how SLT and lesson arrays work in course module updates (see brainstorm: docs/brainstorms/2026-03-18-project-task-management-brainstorm.md). Omitting `--token` on update leaves tokens unchanged (via `Changed()` guard).
+
+**Limitation:** No way to clear all tokens in v1. Acceptable for now — can add `--clear-tokens` flag later if needed.
+
+### Whitespace trimming: yes
+
+`strings.TrimSpace()` on all three fields. Users will naturally type `"policy_id, asset_name, 50"`. Untrimmed spaces in hex policy IDs would cause silent Cardano-layer failures.
+
+### Empty asset names: allowed
+
+`"policy_id,,quantity"` is valid — Cardano policy-only tokens have empty asset names. Parser must not reject empty middle field.
+
+### Quantity validation: CLI-side
+
+Validate quantity is a non-negative integer string before sending to API. Early validation produces better error messages than API-level rejection.
+
+### Duplicate detection: reject
+
+If the same `policy_id + asset_name` pair appears twice, fail with a clear error. Prevents ambiguous API behavior.
+
+## Error Messages
+
+```
+Error: invalid --token format "bad": expected "policy_id,asset_name,quantity"
+  Example: --token "722c475bebb10...,XP,50"
+
+Error: invalid --token quantity "abc": must be a non-negative integer
+
+Error: duplicate token: policy_id "722c47..." + asset_name "XP" specified twice
+```
+
+## Acceptance Criteria
+
+- [x] `project task create` accepts repeatable `--token "policy_id,asset_name,quantity"` flag
+- [x] `project task update` accepts repeatable `--token` flag with `Changed()` guard
+- [x] Tokens appear in API payload as `"tokens": [{policy_id, asset_name, quantity}]`
+- [x] Omitting `--token` on update does not clear existing tokens
+- [x] Invalid format (wrong field count) returns clear error with example
+- [x] Invalid quantity (non-integer) returns clear error
+- [x] Duplicate policy_id + asset_name rejected with error
+- [x] Empty asset_name allowed (`"policy_id,,quantity"`)
+- [x] Whitespace trimmed from all fields
+- [x] Works with `--output json` (tokens in structured output)
+- [x] No TTY required — fully composable
+- [x] `--help` shows format description and example
+
+## Composability Example
+
+```bash
+# Create task with tokens, capture result
+RESULT=$(andamio project task create "$PROJECT_ID" \
+  --title "Build dApp" \
+  --lovelace 5000000 \
+  --expiration 2026-06-01 \
+  --token "$POLICY_ID,$ASSET_NAME,$QTY" \
+  --output json)
+
+echo "$RESULT" | jq '.data'
+```
+
+## Out of Scope
+
+- `--clear-tokens` flag for removing all tokens on update (follow-up)
+- Alternative token format (`policy_id.asset_name` Blockfrost-style concatenation)
+- Updating task export to include tokens in YAML frontmatter (verify if already present; if not, separate follow-up)
+
+## Sources
+
+- **Origin brainstorm:** [docs/brainstorms/2026-03-18-project-task-management-brainstorm.md](../brainstorms/2026-03-18-project-task-management-brainstorm.md) — tokens included from start as YAML arrays, format: `[{policy_id, asset_name, quantity}]`
+- **GitHub issue:** [#22 — Add --token flag to project task create](https://github.com/Andamio-Platform/andamio-cli/issues/22)
+- **TaskToken struct:** `cmd/andamio/project_task_import.go:53-57`
+- **StringArray flag pattern:** `cmd/andamio/tx_submit.go:36`
+- **Token payload in import:** `cmd/andamio/project_task_import.go:249-251`
+- **Composability audit:** `docs/solutions/architecture/cli-composability-audit-and-fix.md`

--- a/docs/solutions/feature-implementations/project-task-token-flag.md
+++ b/docs/solutions/feature-implementations/project-task-token-flag.md
@@ -1,0 +1,152 @@
+---
+title: "Add --token flag to project task create/update for inline native asset assignment"
+date: 2026-03-20
+problem_type: feature-implementation
+severity: medium
+component: cmd/andamio/project_task.go
+module: project-task
+tags:
+  - cli-flags
+  - cobra
+  - cardano-native-assets
+  - token-assignment
+  - string-array-flag
+  - project-management
+---
+
+# Add --token flag to project task create/update
+
+## Problem Statement
+
+The `andamio project task create` and `project task update` commands had no way to assign Cardano native assets (such as XP tokens) to tasks inline from the command line. Users who needed to attach tokens to individual tasks were forced to go through the bulk Markdown import workflow, which was unnecessarily heavyweight for single-task operations. The API and task import already supported tokens — the CLI create/update commands just lacked the flag.
+
+## Root Cause
+
+The `TaskToken` struct and API payload support existed in `project_task_import.go` (for YAML frontmatter parsing), but `project_task.go` had no corresponding CLI flag to pass token data during inline task creation or updates.
+
+## Solution
+
+Five changes to `cmd/andamio/project_task.go`:
+
+### 1. Flag registration in `init()`
+
+```go
+projectTaskCreateCmd.Flags().StringArray("token", nil,
+    `Native asset token (repeatable, format: "policy_id,asset_name,quantity")`)
+projectTaskUpdateCmd.Flags().StringArray("token", nil,
+    `Native asset token (repeatable, format: "policy_id,asset_name,quantity")`)
+```
+
+`StringArray` is used instead of `StringSlice` because the value itself contains commas as the delimiter between fields. `StringSlice` would incorrectly split on those commas.
+
+### 2. `parseTokenFlags` helper
+
+Converts raw flag strings into `[]TaskToken` with validation:
+
+```go
+func parseTokenFlags(values []string) ([]TaskToken, error) {
+    tokens := make([]TaskToken, 0, len(values))
+    seen := make(map[string]bool)
+    for _, v := range values {
+        parts := strings.SplitN(v, ",", 3)
+        if len(parts) != 3 {
+            return nil, fmt.Errorf("invalid --token format %q: expected ...", v)
+        }
+        policyID := strings.TrimSpace(parts[0])
+        assetName := strings.TrimSpace(parts[1])
+        quantity := strings.TrimSpace(parts[2])
+        // Validate: policy ID (56 hex chars), quantity (non-negative int), duplicates
+        // Empty asset_name is allowed (Cardano policy-only tokens)
+        ...
+    }
+    return tokens, nil
+}
+```
+
+### 3. Create payload wiring
+
+```go
+tokenStrs, _ := cmd.Flags().GetStringArray("token")
+if len(tokenStrs) > 0 {
+    tokens, err := parseTokenFlags(tokenStrs)
+    if err != nil { return err }
+    payload["tokens"] = tokens
+}
+```
+
+### 4. Update payload wiring (with `Changed()` guard)
+
+```go
+if cmd.Flags().Changed("token") {
+    tokenStrs, _ := cmd.Flags().GetStringArray("token")
+    tokens, err := parseTokenFlags(tokenStrs)
+    if err != nil { return err }
+    payload["tokens"] = tokens
+}
+```
+
+### 5. Struct reuse
+
+The existing `TaskToken` struct from `project_task_import.go` is reused directly since both files are in the same package (`main`).
+
+## Key Design Decisions
+
+- **Comma as in-value delimiter** -- Safe because Cardano policy IDs are hex strings and asset names are hex-encoded; neither can contain commas.
+- **`StringArray` over `StringSlice`** -- Cobra's `StringSlice` splits on commas internally, which would break the `policyID,assetName,quantity` format. `StringArray` treats each `--token` flag as a single opaque string.
+- **Replace semantics on update** -- When `--token` is passed during update, the entire token array is replaced. Consistent with how the API handles other array fields (SLTs, lessons).
+- **Empty asset name is valid** -- Cardano supports policy-only tokens (no asset name), so `"policyID,,quantity"` is accepted.
+- **Duplicate detection** -- A `seen` map keyed on `policyID:assetName` prevents accidentally sending the same token twice.
+- **Policy ID validation** -- Must be exactly 56 hex characters. Catches truncated/malformed IDs client-side with a clear error instead of a cryptic API error.
+
+## Prevention Strategies
+
+### Default to `StringArray` for multi-value flags
+
+`StringSlice` splits on commas *within* a single flag value. Always use `StringArray` unless you specifically want comma-separated values in a single invocation.
+
+### Validate domain-specific inputs at the CLI boundary
+
+Cardano identifiers have well-known formats (56 hex chars for policy IDs, 64 hex chars for tx hashes). Validate these in `RunE` before any API call. Return clear errors with the expected format.
+
+### Search stdlib before writing helpers
+
+Before writing utility functions, check Go's standard library. `strings.Contains`, `encoding/hex.DecodeString`, and `slices.Contains` cover most needs. A custom `contains` function was caught during review -- always use `strings.Contains`.
+
+### Guard optional update flags with `Changed()`
+
+For any update command, omitting a flag must mean "leave unchanged," not "set to zero value":
+
+```go
+if cmd.Flags().Changed("token") {
+    payload["tokens"] = tokens
+}
+```
+
+## Checklist for Adding CLI Flags
+
+1. **Flag type**: Multi-value with structured content? Use `StringArray`, not `StringSlice`.
+2. **Validation**: Known format (hex, UUID, date)? Add validation in `RunE` before API calls.
+3. **Update semantics**: Wrap in `cmd.Flags().Changed()` guard.
+4. **Reuse check**: Search `cmd/andamio/*.go` for existing structs and `internal/` for helpers.
+5. **Help text**: Include expected format and example in flag description.
+6. **Wire-up**: Register in `init()`, include in payload construction.
+
+## Testing Guidance
+
+- **Parsing correctness**: Verify `StringArray` preserves comma-containing values as single elements.
+- **Validation rejection**: Test invalid inputs produce clear errors before any HTTP call.
+- **Update semantics**: Test flag-provided (value in payload) vs flag-omitted (key absent from payload).
+- **Use stdlib in tests**: Use `strings.Contains` for error matching, not custom helpers.
+
+## Related Documentation
+
+- `docs/plans/2026-03-20-feat-add-token-flag-to-task-create-update-plan.md` -- Implementation plan
+- `docs/brainstorms/2026-03-18-project-task-management-brainstorm.md` -- Origin brainstorm where tokens were first specified
+- `docs/solutions/architecture/cli-composability-audit-and-fix.md` -- Composability contract (progress to stderr, data to stdout)
+- `docs/solutions/architecture/non-interactive-cli-stdin-picker-removal.md` -- Non-interactive CLI requirements
+- `docs/solutions/security-issues/cli-security-hardening-input-validation.md` -- Input validation patterns
+
+## Related Issues
+
+- [GitHub Issue #22](https://github.com/Andamio-Platform/andamio-cli/issues/22) -- Add --token flag to project task create
+- [GitHub PR #23](https://github.com/Andamio-Platform/andamio-cli/pull/23) -- Implementation PR


### PR DESCRIPTION
## Summary
- Adds repeatable `--token "policy_id,asset_name,quantity"` flag to `project task create` and `project task update`
- Reuses `TaskToken` struct from task import and `StringArray` pattern from tx submit
- Includes validation: format, quantity (non-negative integer), duplicates, whitespace trimming
- Empty asset names allowed for Cardano policy-only tokens

## Usage
```bash
andamio project task create <project-id> \
  --title "Build a dApp" \
  --lovelace 5000000 \
  --expiration 2026-06-01 \
  --token "722c475bebb10...,XP,50" \
  --token "def456...,RewardToken,100"

andamio project task update 3 --project-id <id> \
  --token "abc123...,XP,50"
```

## Test plan
- [x] 12 unit tests for `parseTokenFlags` covering valid input, edge cases, and error paths
- [x] All existing tests pass
- [x] Build succeeds, `--help` shows flag with format description
- [ ] Manual: create task with `--token` against preprod API
- [ ] Manual: update task with `--token` against preprod API

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)