### PR TITLE
feat: add --course flag for name-based course resolution

### DIFF
--- a/cmd/andamio/course.go
+++ b/cmd/andamio/course.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strings"
 	"unicode/utf8"
 
 	"github.com/Andamio-Platform/andamio-cli/internal/apierr"
@@ -37,17 +38,31 @@ var courseGetCmd = &cobra.Command{
 }
 
 var courseModulesCmd = &cobra.Command{
-	Use:   "modules <course-id>",
+	Use:   "modules [course-id]",
 	Short: "List modules for a course",
-	Args:  cobra.ExactArgs(1),
-	RunE:  runCourseModules,
+	Long: `List modules for a course.
+
+The course can be specified by ID (positional arg) or by name (--course flag):
+  andamio course modules <course-id>
+  andamio course modules --course "Intro to Cardano"
+
+Find your course IDs with: andamio teacher courses`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runCourseModules,
 }
 
 var courseSltsCmd = &cobra.Command{
-	Use:   "slts <course-id> <module-code>",
+	Use:   "slts [course-id] <module-code>",
 	Short: "List SLTs for a course module",
-	Args:  cobra.ExactArgs(2),
-	RunE:  runCourseSlts,
+	Long: `List SLTs for a course module.
+
+The course can be specified by ID (first positional arg) or by name (--course flag):
+  andamio course slts <course-id> <module-code>
+  andamio course slts <module-code> --course "Intro to Cardano"
+
+Find your course IDs with: andamio teacher courses`,
+	Args: cobra.RangeArgs(1, 2),
+	RunE: runCourseSlts,
 }
 
 var courseLessonCmd = &cobra.Command{
@@ -98,6 +113,10 @@ func init() {
 	courseCmd.AddCommand(courseLessonCmd)
 	courseCmd.AddCommand(courseAssignmentCmd)
 	courseCmd.AddCommand(courseIntroCmd)
+
+	// --course flag for name-based course resolution
+	courseModulesCmd.Flags().String("course", "", "Course name or substring (alternative to course-id arg)")
+	courseSltsCmd.Flags().String("course", "", "Course name or substring (alternative to course-id arg)")
 }
 
 // getJSON is a helper for simple GET endpoints that return JSON
@@ -193,10 +212,101 @@ func printList(path, emptyMsg, titleKey, idKey string, usePost bool) error {
 	return output.PrintList(items, titleKey, idKey)
 }
 
-func runCourseModules(cmd *cobra.Command, args []string) error {
-	courseID := args[0]
+// teacherCourse holds the fields needed from the teacher courses list
+type teacherCourse struct {
+	CourseID string
+	Title    string
+}
 
+// fetchTeacherCourses calls POST /v2/course/teacher/courses/list and returns parsed courses
+func fetchTeacherCourses(c *client.Client) ([]teacherCourse, error) {
+	var resp map[string]interface{}
+	if err := c.Post("/api/v2/course/teacher/courses/list", nil, &resp); err != nil {
+		return nil, fmt.Errorf("failed to list teacher courses: %w", err)
+	}
+
+	data, ok := resp["data"].([]interface{})
+	if !ok || len(data) == 0 {
+		return nil, nil
+	}
+
+	courses := make([]teacherCourse, 0, len(data))
+	for _, item := range data {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		tc := teacherCourse{}
+		tc.CourseID, _ = m["course_id"].(string)
+		if content, ok := m["content"].(map[string]interface{}); ok {
+			tc.Title, _ = content["title"].(string)
+		}
+		if tc.CourseID != "" {
+			courses = append(courses, tc)
+		}
+	}
+	return courses, nil
+}
+
+// resolveCourseID resolves a course ID from positional args or --course flag.
+// If a positional arg is provided, it is used directly. Otherwise, --course is
+// used for substring matching against the teacher courses list.
+func resolveCourseID(c *client.Client, args []string, argIndex int, cmd *cobra.Command) (string, error) {
+	// If positional arg is available, use it directly
+	if len(args) > argIndex {
+		return args[argIndex], nil
+	}
+
+	// Check --course flag
+	courseName, _ := cmd.Flags().GetString("course")
+	if courseName == "" {
+		return "", fmt.Errorf(
+			"course-id required\n\nList your courses with:\n  andamio teacher courses\n  andamio teacher courses --output json",
+		)
+	}
+
+	// Fetch teacher courses and match by title substring
+	courses, err := fetchTeacherCourses(c)
+	if err != nil {
+		return "", err
+	}
+	if len(courses) == 0 {
+		return "", fmt.Errorf("no teacher courses found")
+	}
+
+	var matches []teacherCourse
+	needle := strings.ToLower(courseName)
+	for _, course := range courses {
+		if strings.Contains(strings.ToLower(course.Title), needle) {
+			matches = append(matches, course)
+		}
+	}
+
+	switch len(matches) {
+	case 0:
+		return "", fmt.Errorf("no course matching %q found\n\nList your courses:\n  andamio teacher courses", courseName)
+	case 1:
+		return matches[0].CourseID, nil
+	default:
+		var lines []string
+		for _, m := range matches {
+			lines = append(lines, fmt.Sprintf("  %s  %s", m.CourseID, m.Title))
+		}
+		return "", fmt.Errorf(
+			"%q matches multiple courses:\n%s\n\nUse a more specific name or pass the course-id directly.",
+			courseName, strings.Join(lines, "\n"),
+		)
+	}
+}
+
+func runCourseModules(cmd *cobra.Command, args []string) error {
 	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+	c := client.New(cfg)
+
+	courseID, err := resolveCourseID(c, args, 0, cmd)
 	if err != nil {
 		return err
 	}
@@ -280,12 +390,24 @@ func runCourseModulesTeacher(cfg *config.Config, courseID string) error {
 }
 
 func runCourseSlts(cmd *cobra.Command, args []string) error {
-	courseID := args[0]
-	moduleCode := args[1]
-
 	cfg, err := config.Load()
 	if err != nil {
 		return err
+	}
+	c := client.New(cfg)
+
+	var courseID, moduleCode string
+	if len(args) == 2 {
+		// slts <course-id> <module-code>
+		courseID = args[0]
+		moduleCode = args[1]
+	} else {
+		// slts <module-code> --course "Name"
+		moduleCode = args[0]
+		courseID, err = resolveCourseID(c, nil, 0, cmd)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Use teacher endpoint for lesson presence data when JWT is available

--- a/cmd/andamio/course_export.go
+++ b/cmd/andamio/course_export.go
@@ -22,7 +22,7 @@ import (
 )
 
 var courseExportCmd = &cobra.Command{
-	Use:   "export <course-id> <module-code>",
+	Use:   "export [course-id] <module-code>",
 	Short: "Export a course module to compiled/ format",
 	Long: `Export a course module to the compiled/ directory format used by lesson-coach.
 
@@ -35,8 +35,12 @@ This creates a directory structure that can be edited locally and re-imported:
   ├── assignment.md       # Module assignment (if present)
   └── assets/             # Downloaded images
 
+The course can be specified by ID (first arg) or by name (--course flag):
+  andamio course export <course-id> <module-code>
+  andamio course export <module-code> --course "Intro to Cardano"
+
 Requires user authentication via 'andamio user login'.`,
-	Args: cobra.ExactArgs(2),
+	Args: cobra.RangeArgs(1, 2),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// Check user auth
 		cfg, err := config.Load()
@@ -55,6 +59,7 @@ func init() {
 	courseCmd.AddCommand(courseExportCmd)
 	courseExportCmd.Flags().String("output-dir", "", "Output directory (default: ./compiled/<course-slug>/<module-code>/)")
 	courseExportCmd.Flags().Bool("force", false, "Overwrite existing directory")
+	courseExportCmd.Flags().String("course", "", "Course name or substring (alternative to course-id arg)")
 }
 
 // ExportResult holds the result of an export operation for structured output
@@ -71,16 +76,27 @@ type ExportResult struct {
 }
 
 func runCourseExport(cmd *cobra.Command, args []string) error {
-	courseID := args[0]
-	moduleCode := args[1]
 	isJSON := output.GetFormat() == output.FormatJSON
 
 	cfg, err := config.Load()
 	if err != nil {
 		return err
 	}
-
 	c := client.New(cfg)
+
+	var courseID, moduleCode string
+	if len(args) == 2 {
+		// export <course-id> <module-code>
+		courseID = args[0]
+		moduleCode = args[1]
+	} else {
+		// export <module-code> --course "Name"
+		moduleCode = args[0]
+		courseID, err = resolveCourseID(c, nil, 0, cmd)
+		if err != nil {
+			return err
+		}
+	}
 
 	// Single teacher endpoint fetches everything
 	if !isJSON {

--- a/cmd/andamio/course_import.go
+++ b/cmd/andamio/course_import.go
@@ -39,8 +39,8 @@ var (
 
 func init() {
 	courseCmd.AddCommand(courseImportCmd)
-	courseImportCmd.Flags().String("course-id", "", "Course ID to import into (required)")
-	courseImportCmd.MarkFlagRequired("course-id")
+	courseImportCmd.Flags().String("course-id", "", "Course ID to import into")
+	courseImportCmd.Flags().String("course", "", "Course name or substring (alternative to --course-id)")
 	courseImportCmd.Flags().Bool("dry-run", false, "Show the API payload without sending it")
 	courseImportCmd.Flags().Bool("create", false, "Create the module if it doesn't exist")
 	courseImportCmd.Flags().Int("sort-order", 0, "Sort order when creating a new module (used with --create)")
@@ -57,8 +57,9 @@ The directory should contain:
   - introduction.md (optional)
   - assignment.md (optional)
 
-Example:
+Examples:
   andamio course import ./compiled/my-course/101 --course-id abc123
+  andamio course import ./compiled/my-course/101 --course "Intro to Cardano"
 
 New images in assets/ are automatically uploaded to the CDN.
 Previously uploaded images are preserved via .image-manifest.json.
@@ -278,11 +279,24 @@ func importModule(p ImportParams) (*ImportResult, error) {
 
 func runCourseImport(cmd *cobra.Command, args []string) error {
 	moduleDir := args[0]
-	courseID, _ := cmd.Flags().GetString("course-id")
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
 	createMode, _ := cmd.Flags().GetBool("create")
 	sortOrder, _ := cmd.Flags().GetInt("sort-order")
 	isJSON := output.GetFormat() == output.FormatJSON
+
+	// Resolve course ID from --course-id or --course flag
+	courseID, _ := cmd.Flags().GetString("course-id")
+	if courseID == "" {
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+		c := client.New(cfg)
+		courseID, err = resolveCourseID(c, nil, 0, cmd)
+		if err != nil {
+			return fmt.Errorf("--course-id or --course is required\n\nList your courses with:\n  andamio teacher courses")
+		}
+	}
 
 	// Validate directory exists
 	info, err := os.Stat(moduleDir)

--- a/cmd/andamio/course_import_all.go
+++ b/cmd/andamio/course_import_all.go
@@ -16,8 +16,8 @@ import (
 
 func init() {
 	courseCmd.AddCommand(courseImportAllCmd)
-	courseImportAllCmd.Flags().String("course-id", "", "Course ID to import into (required)")
-	courseImportAllCmd.MarkFlagRequired("course-id")
+	courseImportAllCmd.Flags().String("course-id", "", "Course ID to import into")
+	courseImportAllCmd.Flags().String("course", "", "Course name or substring (alternative to --course-id)")
 	courseImportAllCmd.Flags().Bool("create", false, "Create modules that don't exist")
 	courseImportAllCmd.Flags().Bool("dry-run", false, "Show what would be imported without sending")
 	courseImportAllCmd.Flags().Bool("continue-on-error", false, "Continue past failures")
@@ -31,9 +31,10 @@ var courseImportAllCmd = &cobra.Command{
 
 Scans for subdirectories containing outline.md and imports each one.
 
-Example:
+Examples:
   andamio course import-all ./compiled/my-course --course-id <id>
   andamio course import-all ./compiled/my-course --course-id <id> --create
+  andamio course import-all ./compiled/my-course --course "Intro to Cardano"
 
 Requires user authentication via 'andamio user login'.`,
 	Args: cobra.ExactArgs(1),
@@ -61,12 +62,25 @@ type ModuleImportSummary struct {
 
 func runImportAll(cmd *cobra.Command, args []string) error {
 	baseDir := args[0]
-	courseID, _ := cmd.Flags().GetString("course-id")
 	createMode, _ := cmd.Flags().GetBool("create")
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
 	continueOnError, _ := cmd.Flags().GetBool("continue-on-error")
 	sortOrderStart, _ := cmd.Flags().GetInt("sort-order-start")
 	isJSON := output.GetFormat() == output.FormatJSON
+
+	// Resolve course ID from --course-id or --course flag
+	courseID, _ := cmd.Flags().GetString("course-id")
+	if courseID == "" {
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+		c := client.New(cfg)
+		courseID, err = resolveCourseID(c, nil, 0, cmd)
+		if err != nil {
+			return fmt.Errorf("--course-id or --course is required\n\nList your courses with:\n  andamio teacher courses")
+		}
+	}
 
 	// Find module subdirectories (contain outline.md)
 	entries, err := os.ReadDir(baseDir)

--- a/docs/plans/2026-03-20-feat-interactive-course-selection-for-teachers-plan.md
+++ b/docs/plans/2026-03-20-feat-interactive-course-selection-for-teachers-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: interactive course selection for teachers"
 type: feat
-status: proposed
+status: completed
 date: 2026-03-20
 issue: 6
 ---


### PR DESCRIPTION
## Summary
- Adds `--course` flag to 5 course commands as an alternative to opaque course IDs
- Teachers can specify courses by name substring: `--course "Intro to Cardano"`
- Unique match resolves to course ID; ambiguous matches list all candidates with IDs
- No interactive prompts — fully composable (no stdin reads, works in pipes/CI/agents)

## Affected Commands
| Command | New Usage |
|---------|-----------|
| `course export` | `export <module> --course "Name"` |
| `course import` | `import <path> --course "Name"` |
| `course import-all` | `import-all <dir> --course "Name"` |
| `course modules` | `modules --course "Name"` |
| `course slts` | `slts <module> --course "Name"` |

All existing positional-arg usage (`export <course-id> <module>`) continues working unchanged.

## Test plan
- [x] All existing tests pass
- [x] Build succeeds
- [x] `--help` shows `--course` flag on all 5 commands
- [ ] Manual: `course modules --course "Cardano"` resolves correctly
- [ ] Manual: ambiguous name shows candidates with IDs

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: CLI-only change with no server-side impact.

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)