### PR TITLE
feat: add project owner commands (PR 2/7 — full API coverage)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,10 @@ The app URL is derived from the API URL by replacing `.api.` with `.app.` in the
 |---------|----------|------|-------------|
 | `project list` | `/api/v2/project/user/projects/list` | either | List projects |
 | `project get <id>` | `/api/v2/project/user/project/{id}` | either | Project details |
+| `project owner list` | `/v2/project/owner/projects/list` | jwt | List projects you own |
+| `project owner create --title <t>` | `/v2/project/owner/project/create` | jwt | Create project. `--description`, `--image-url`, `--video-url`, `--category`, `--public` |
+| `project owner update --project-id <id>` | `/v2/project/owner/project/update` | jwt | Update project metadata. Only changed flags sent |
+| `project owner register --project-id <id>` | `/v2/project/owner/project/register` | jwt | Register on-chain project with off-chain metadata |
 | `project task list <project-id>` | `/v2/project/manager/tasks/list` | jwt | List tasks (manager) |
 | `project task get <index> --project-id <id>` | `/v2/project/manager/tasks/list` | jwt | Get task by index (filters from list) |
 | `project task create <project-id>` | `/v2/project/manager/task/create` | jwt | Create task. Flags: --title, --lovelace, --expiration, --github-issue |

--- a/cmd/andamio/course.go
+++ b/cmd/andamio/course.go
@@ -1,12 +1,10 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"net/url"
 	"os"
 	"strings"
-	"unicode/utf8"
 
 	"github.com/Andamio-Platform/andamio-cli/internal/apierr"
 	"github.com/Andamio-Platform/andamio-cli/internal/client"
@@ -117,115 +115,6 @@ func init() {
 	// --course flag for name-based course resolution
 	courseModulesCmd.Flags().String("course", "", "Course name or substring (alternative to course-id arg)")
 	courseSltsCmd.Flags().String("course", "", "Course name or substring (alternative to course-id arg)")
-}
-
-// jwtAuthPreRunE is a shared PersistentPreRunE that chains with root (for --output flag)
-// and checks for JWT authentication. Used by all role-based parent commands.
-func jwtAuthPreRunE(cmd *cobra.Command, args []string) error {
-	if err := rootCmd.PersistentPreRunE(cmd, args); err != nil {
-		return err
-	}
-	cfg, err := config.Load()
-	if err != nil {
-		return err
-	}
-	if !cfg.HasUserAuth() {
-		return &apierr.AuthError{Message: "not authenticated. Run 'andamio user login' first"}
-	}
-	return nil
-}
-
-// getJSON is a helper for simple GET endpoints that return JSON
-func getJSON(path string) error {
-	cfg, err := config.Load()
-	if err != nil {
-		return err
-	}
-
-	c := client.New(cfg)
-	var result map[string]interface{}
-	if err := c.Get(path, &result); err != nil {
-		return err
-	}
-
-	return output.PrintJSON(result)
-}
-
-// postJSON is a helper for simple POST endpoints that return JSON (no body)
-func postJSON(path string) error {
-	cfg, err := config.Load()
-	if err != nil {
-		return err
-	}
-
-	c := client.New(cfg)
-	var result map[string]interface{}
-	if err := c.Post(path, nil, &result); err != nil {
-		return err
-	}
-
-	return output.PrintJSON(result)
-}
-
-// getJSONWithHint wraps getJSON and replaces NotFoundError messages with a contextual hint.
-func getJSONWithHint(path, notFoundHint string) error {
-	err := getJSON(path)
-	if err != nil {
-		var notFound *apierr.NotFoundError
-		if errors.As(err, &notFound) {
-			return &apierr.NotFoundError{Message: notFoundHint}
-		}
-		return err
-	}
-	return nil
-}
-
-// truncateUTF8 truncates a string to maxRunes runes, appending "..." if truncated.
-func truncateUTF8(s string, maxRunes int) string {
-	if utf8.RuneCountInString(s) <= maxRunes {
-		return s
-	}
-	runes := []rune(s)
-	return string(runes[:maxRunes-3]) + "..."
-}
-
-// printList fetches a list endpoint and prints using PrintList
-func printList(path, emptyMsg, titleKey, idKey string, usePost bool) error {
-	cfg, err := config.Load()
-	if err != nil {
-		return err
-	}
-
-	c := client.New(cfg)
-	var response map[string]interface{}
-	var reqErr error
-	if usePost {
-		reqErr = c.Post(path, nil, &response)
-	} else {
-		reqErr = c.Get(path, &response)
-	}
-	if reqErr != nil {
-		return reqErr
-	}
-
-	data, ok := response["data"].([]interface{})
-	if !ok || len(data) == 0 {
-		if output.GetFormat() == output.FormatJSON {
-			return output.PrintJSON(map[string]interface{}{"data": []interface{}{}})
-		} else {
-			fmt.Fprintln(os.Stderr, emptyMsg)
-		}
-		return nil
-	}
-
-	items := make([]map[string]interface{}, 0, len(data))
-	for _, item := range data {
-		if m, ok := item.(map[string]interface{}); ok {
-			items = append(items, m)
-		}
-	}
-
-	return output.PrintList(items, titleKey, idKey)
 }
 
 // teacherCourse holds the fields needed from the teacher courses list

--- a/cmd/andamio/helpers.go
+++ b/cmd/andamio/helpers.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"unicode/utf8"
+
+	"github.com/Andamio-Platform/andamio-cli/internal/apierr"
+	"github.com/Andamio-Platform/andamio-cli/internal/client"
+	"github.com/Andamio-Platform/andamio-cli/internal/config"
+	"github.com/Andamio-Platform/andamio-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+// jwtAuthPreRunE is a shared PersistentPreRunE that chains with root (for --output flag)
+// and checks for JWT authentication. Used by all role-based parent commands.
+func jwtAuthPreRunE(cmd *cobra.Command, args []string) error {
+	if err := rootCmd.PersistentPreRunE(cmd, args); err != nil {
+		return err
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+	if !cfg.HasUserAuth() {
+		return &apierr.AuthError{Message: "not authenticated. Run 'andamio user login' first"}
+	}
+	return nil
+}
+
+// getJSON is a helper for simple GET endpoints that return JSON
+func getJSON(path string) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
+	c := client.New(cfg)
+	var result map[string]interface{}
+	if err := c.Get(path, &result); err != nil {
+		return err
+	}
+
+	return output.PrintJSON(result)
+}
+
+// postJSON is a helper for simple POST endpoints that return JSON (no body)
+func postJSON(path string) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
+	c := client.New(cfg)
+	var result map[string]interface{}
+	if err := c.Post(path, nil, &result); err != nil {
+		return err
+	}
+
+	return output.PrintJSON(result)
+}
+
+// getJSONWithHint wraps getJSON and replaces NotFoundError messages with a contextual hint.
+func getJSONWithHint(path, notFoundHint string) error {
+	err := getJSON(path)
+	if err != nil {
+		var notFound *apierr.NotFoundError
+		if errors.As(err, &notFound) {
+			return &apierr.NotFoundError{Message: notFoundHint}
+		}
+		return err
+	}
+	return nil
+}
+
+// truncateUTF8 truncates a string to maxRunes runes, appending "..." if truncated.
+func truncateUTF8(s string, maxRunes int) string {
+	if utf8.RuneCountInString(s) <= maxRunes {
+		return s
+	}
+	runes := []rune(s)
+	return string(runes[:maxRunes-3]) + "..."
+}
+
+// printList fetches a list endpoint and prints using PrintList
+func printList(path, emptyMsg, titleKey, idKey string, usePost bool) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
+	c := client.New(cfg)
+	var response map[string]interface{}
+	var reqErr error
+	if usePost {
+		reqErr = c.Post(path, nil, &response)
+	} else {
+		reqErr = c.Get(path, &response)
+	}
+	if reqErr != nil {
+		return reqErr
+	}
+
+	data, ok := response["data"].([]interface{})
+	if !ok || len(data) == 0 {
+		if output.GetFormat() == output.FormatJSON {
+			return output.PrintJSON(map[string]interface{}{"data": []interface{}{}})
+		} else {
+			fmt.Fprintln(os.Stderr, emptyMsg)
+		}
+		return nil
+	}
+
+	items := make([]map[string]interface{}, 0, len(data))
+	for _, item := range data {
+		if m, ok := item.(map[string]interface{}); ok {
+			items = append(items, m)
+		}
+	}
+
+	return output.PrintList(items, titleKey, idKey)
+}

--- a/cmd/andamio/project_owner.go
+++ b/cmd/andamio/project_owner.go
@@ -1,0 +1,272 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Andamio-Platform/andamio-cli/internal/client"
+	"github.com/Andamio-Platform/andamio-cli/internal/config"
+	"github.com/Andamio-Platform/andamio-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+var projectOwnerCmd = &cobra.Command{
+	Use:               "owner",
+	Short:             "Project owner operations (requires user login)",
+	PersistentPreRunE: jwtAuthPreRunE,
+}
+
+var projectOwnerListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List projects you own",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return printList(
+			"/api/v2/project/owner/projects/list",
+			"No owned projects found.",
+			"content.title", "project_id", true,
+		)
+	},
+}
+
+var projectOwnerCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a new project",
+	Long: `Create a new off-chain project record.
+
+For on-chain project creation, use: andamio tx run /v2/tx/instance/owner/project/create
+Then register the project with: andamio project owner register
+
+Examples:
+  andamio project owner create --title "Community Development"
+  andamio project owner create --title "My Project" --description "Build things" --public`,
+	RunE: runProjectOwnerCreate,
+}
+
+var projectOwnerUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update project metadata",
+	Long: `Update an existing project's metadata. Only specified flags are updated; omitted fields are unchanged.
+
+Examples:
+  andamio project owner update --project-id <id> --title "New Title"
+  andamio project owner update --project-id <id> --description "Updated description" --public=false`,
+	RunE: runProjectOwnerUpdate,
+}
+
+var projectOwnerRegisterCmd = &cobra.Command{
+	Use:   "register",
+	Short: "Register an on-chain project with off-chain metadata",
+	Long: `Register a project that has been created on-chain. Links the on-chain record
+to off-chain metadata (title, description, etc.).
+
+Typical flow:
+  1. andamio tx run /v2/tx/instance/owner/project/create --body '...' --skey ... --tx-type project_create
+  2. andamio project owner register --project-id <id>
+
+Examples:
+  andamio project owner register --project-id <id>
+  andamio project owner register --project-id <id> --title "My Project" --public`,
+	RunE: runProjectOwnerRegister,
+}
+
+func init() {
+	projectCmd.AddCommand(projectOwnerCmd)
+	projectOwnerCmd.AddCommand(projectOwnerListCmd)
+	projectOwnerCmd.AddCommand(projectOwnerCreateCmd)
+	projectOwnerCmd.AddCommand(projectOwnerUpdateCmd)
+	projectOwnerCmd.AddCommand(projectOwnerRegisterCmd)
+
+	// create flags
+	projectOwnerCreateCmd.Flags().String("title", "", "Project title (required)")
+	projectOwnerCreateCmd.MarkFlagRequired("title")
+	projectOwnerCreateCmd.Flags().String("description", "", "Project description")
+	projectOwnerCreateCmd.Flags().String("image-url", "", "Project image URL")
+	projectOwnerCreateCmd.Flags().String("video-url", "", "Project video URL")
+	projectOwnerCreateCmd.Flags().String("category", "", "Project category")
+	projectOwnerCreateCmd.Flags().Bool("public", false, "Make project publicly visible")
+
+	// update flags
+	projectOwnerUpdateCmd.Flags().String("project-id", "", "Project ID (required)")
+	projectOwnerUpdateCmd.MarkFlagRequired("project-id")
+	projectOwnerUpdateCmd.Flags().String("title", "", "Project title")
+	projectOwnerUpdateCmd.Flags().String("description", "", "Project description")
+	projectOwnerUpdateCmd.Flags().String("image-url", "", "Project image URL")
+	projectOwnerUpdateCmd.Flags().String("video-url", "", "Project video URL")
+	projectOwnerUpdateCmd.Flags().Bool("public", false, "Set project public visibility")
+
+	// register flags
+	projectOwnerRegisterCmd.Flags().String("project-id", "", "Project ID (required)")
+	projectOwnerRegisterCmd.MarkFlagRequired("project-id")
+	projectOwnerRegisterCmd.Flags().String("tx-hash", "", "Transaction hash from on-chain creation")
+	projectOwnerRegisterCmd.Flags().String("title", "", "Project title")
+	projectOwnerRegisterCmd.Flags().String("description", "", "Project description")
+	projectOwnerRegisterCmd.Flags().String("image-url", "", "Project image URL")
+	projectOwnerRegisterCmd.Flags().String("video-url", "", "Project video URL")
+	projectOwnerRegisterCmd.Flags().String("category", "", "Project category")
+	projectOwnerRegisterCmd.Flags().Bool("public", false, "Make project publicly visible")
+}
+
+func runProjectOwnerCreate(cmd *cobra.Command, args []string) error {
+	title, _ := cmd.Flags().GetString("title")
+	description, _ := cmd.Flags().GetString("description")
+	imageURL, _ := cmd.Flags().GetString("image-url")
+	videoURL, _ := cmd.Flags().GetString("video-url")
+	category, _ := cmd.Flags().GetString("category")
+	isPublic, _ := cmd.Flags().GetBool("public")
+	isJSON := output.GetFormat() == output.FormatJSON
+
+	payload := map[string]interface{}{
+		"title": title,
+	}
+	if description != "" {
+		payload["description"] = description
+	}
+	if imageURL != "" {
+		payload["image_url"] = imageURL
+	}
+	if videoURL != "" {
+		payload["video_url"] = videoURL
+	}
+	if category != "" {
+		payload["category"] = category
+	}
+	if cmd.Flags().Changed("public") {
+		payload["is_public"] = isPublic
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
+	if !isJSON {
+		fmt.Fprintf(os.Stderr, "Creating project: %s\n", title)
+	}
+
+	c := client.New(cfg)
+	var resp map[string]interface{}
+	if err := c.Post("/api/v2/project/owner/project/create", payload, &resp); err != nil {
+		return fmt.Errorf("failed to create project: %w", err)
+	}
+
+	if isJSON {
+		return output.PrintJSON(resp)
+	}
+
+	fmt.Fprintf(os.Stderr, "Project created.\n")
+	if id, ok := resp["project_id"].(string); ok {
+		fmt.Printf("project_id: %s\n", id)
+	}
+	return nil
+}
+
+func runProjectOwnerUpdate(cmd *cobra.Command, args []string) error {
+	projectID, _ := cmd.Flags().GetString("project-id")
+	isJSON := output.GetFormat() == output.FormatJSON
+
+	data := map[string]interface{}{}
+	if cmd.Flags().Changed("title") {
+		v, _ := cmd.Flags().GetString("title")
+		data["title"] = v
+	}
+	if cmd.Flags().Changed("description") {
+		v, _ := cmd.Flags().GetString("description")
+		data["description"] = v
+	}
+	if cmd.Flags().Changed("image-url") {
+		v, _ := cmd.Flags().GetString("image-url")
+		data["image_url"] = v
+	}
+	if cmd.Flags().Changed("video-url") {
+		v, _ := cmd.Flags().GetString("video-url")
+		data["video_url"] = v
+	}
+	if cmd.Flags().Changed("public") {
+		v, _ := cmd.Flags().GetBool("public")
+		data["is_public"] = v
+	}
+
+	if len(data) == 0 {
+		return fmt.Errorf("no fields to update. Specify at least one of: --title, --description, --image-url, --video-url, --public")
+	}
+
+	payload := map[string]interface{}{
+		"project_id": projectID,
+		"data":       data,
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
+	if !isJSON {
+		fmt.Fprintf(os.Stderr, "Updating project %s\n", projectID)
+	}
+
+	c := client.New(cfg)
+	var resp map[string]interface{}
+	if err := c.Post("/api/v2/project/owner/project/update", payload, &resp); err != nil {
+		return fmt.Errorf("failed to update project: %w", err)
+	}
+
+	if isJSON {
+		return output.PrintJSON(resp)
+	}
+
+	fmt.Fprintf(os.Stderr, "Project updated.\n")
+	return nil
+}
+
+func runProjectOwnerRegister(cmd *cobra.Command, args []string) error {
+	projectID, _ := cmd.Flags().GetString("project-id")
+	isJSON := output.GetFormat() == output.FormatJSON
+
+	payload := map[string]interface{}{
+		"project_id": projectID,
+	}
+	if v, _ := cmd.Flags().GetString("tx-hash"); v != "" {
+		payload["tx_hash"] = v
+	}
+	if v, _ := cmd.Flags().GetString("title"); v != "" {
+		payload["title"] = v
+	}
+	if v, _ := cmd.Flags().GetString("description"); v != "" {
+		payload["description"] = v
+	}
+	if v, _ := cmd.Flags().GetString("image-url"); v != "" {
+		payload["image_url"] = v
+	}
+	if v, _ := cmd.Flags().GetString("video-url"); v != "" {
+		payload["video_url"] = v
+	}
+	if v, _ := cmd.Flags().GetString("category"); v != "" {
+		payload["category"] = v
+	}
+	if cmd.Flags().Changed("public") {
+		v, _ := cmd.Flags().GetBool("public")
+		payload["is_public"] = v
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
+	if !isJSON {
+		fmt.Fprintf(os.Stderr, "Registering project %s\n", projectID)
+	}
+
+	c := client.New(cfg)
+	var resp map[string]interface{}
+	if err := c.Post("/api/v2/project/owner/project/register", payload, &resp); err != nil {
+		return fmt.Errorf("failed to register project: %w", err)
+	}
+
+	if isJSON {
+		return output.PrintJSON(resp)
+	}
+
+	fmt.Fprintf(os.Stderr, "Project registered.\n")
+	return nil
+}

--- a/cmd/andamio/project_owner.go
+++ b/cmd/andamio/project_owner.go
@@ -215,6 +215,9 @@ func runProjectOwnerUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Fprintf(os.Stderr, "Project updated.\n")
+	if id, ok := resp["project_id"].(string); ok {
+		fmt.Printf("project_id: %s\n", id)
+	}
 	return nil
 }
 
@@ -268,5 +271,8 @@ func runProjectOwnerRegister(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Fprintf(os.Stderr, "Project registered.\n")
+	if id, ok := resp["project_id"].(string); ok {
+		fmt.Printf("project_id: %s\n", id)
+	}
 	return nil
 }

--- a/cmd/andamio/project_task.go
+++ b/cmd/andamio/project_task.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Andamio-Platform/andamio-cli/internal/apierr"
 	"github.com/Andamio-Platform/andamio-cli/internal/client"
 	"github.com/Andamio-Platform/andamio-cli/internal/config"
 	"github.com/Andamio-Platform/andamio-cli/internal/output"
@@ -16,22 +15,9 @@ import (
 )
 
 var projectTaskCmd = &cobra.Command{
-	Use:   "task",
-	Short: "Manage project tasks (manager role)",
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		// Chain with root's PersistentPreRunE (output format)
-		if err := rootCmd.PersistentPreRunE(cmd, args); err != nil {
-			return err
-		}
-		cfg, err := config.Load()
-		if err != nil {
-			return err
-		}
-		if !cfg.HasUserAuth() {
-			return &apierr.AuthError{Message: "not authenticated. Run 'andamio user login' first"}
-		}
-		return nil
-	},
+	Use:               "task",
+	Short:             "Manage project tasks (manager role)",
+	PersistentPreRunE: jwtAuthPreRunE,
 }
 
 var projectTaskListCmd = &cobra.Command{

--- a/docs/solutions/architecture/cmd-package-helper-placement-and-output-consistency.md
+++ b/docs/solutions/architecture/cmd-package-helper-placement-and-output-consistency.md
@@ -1,0 +1,164 @@
+---
+title: "Fix: Extract shared helpers to helpers.go and enforce stdout consistency"
+date: 2026-03-21
+category: architecture
+tags:
+  - go
+  - cli
+  - cobra
+  - refactor
+  - composability
+  - architecture
+  - auth
+  - code-review
+severity:
+  - P2
+  - P3
+component:
+  - cmd/andamio/helpers.go
+  - cmd/andamio/course.go
+  - cmd/andamio/project_task.go
+  - cmd/andamio/project_owner.go
+related_prs:
+  - 33
+  - 15
+  - 26
+---
+
+# Extract Shared Helpers to `helpers.go` and Enforce stdout Consistency
+
+## Problem
+
+During code review of PR #33 ("feat: add project owner commands"), three quality issues were identified:
+
+1. **Cross-cutting helpers in domain file (P2)**: Six shared functions (`jwtAuthPreRunE`, `getJSON`, `postJSON`, `getJSONWithHint`, `truncateUTF8`, `printList`) lived in `course.go` — a domain-specific file for course commands. These helpers were imported by `manager.go`, `teacher.go`, `project_owner.go`, and `project_task.go`, creating misleading coupling.
+
+2. **Incomplete refactor (P2)**: PR #33 extracted `jwtAuthPreRunE` from inline closures in `manager.go` and `teacher.go` but missed `project_task.go:21-35`, which still had the identical 12-line inline closure.
+
+3. **Inconsistent stdout output (P3)**: `project owner create` printed `project_id: <id>` to stdout on success, but `update` and `register` emitted nothing to stdout in text mode — only stderr messages.
+
+## Root Cause
+
+1. **Helper accumulation by proximity**: `course.go` was the first command file written and contained the first helper (`getJSON`). Subsequent helpers were added there because the pattern already existed, not because they belonged to the course domain. By the time 6 helpers lived there, the file was half infrastructure.
+
+2. **Search was not exhaustive**: The refactor searched `manager.go` and `teacher.go` (the files being actively changed) but did not grep for all copies of the inline pattern across the entire `cmd/andamio/` package.
+
+3. **First-mover pattern not enforced**: `project owner create` set the stdout convention but there was no documented rule requiring mutating commands to match it. `update` and `register` were written later without copying the pattern.
+
+## Solution
+
+### 1. Created `cmd/andamio/helpers.go`
+
+Moved all 6 cross-cutting helpers from `course.go` into a dedicated file with no domain affiliation:
+
+```go
+// helpers.go — shared helpers for all command files
+package main
+
+func jwtAuthPreRunE(cmd *cobra.Command, args []string) error { ... }
+func getJSON(path string) error { ... }
+func postJSON(path string) error { ... }
+func getJSONWithHint(path, notFoundHint string) error { ... }
+func truncateUTF8(s string, maxRunes int) string { ... }
+func printList(path, emptyMsg, titleKey, idKey string, usePost bool) error { ... }
+```
+
+`course.go` now contains only course-specific commands and helpers (`fetchTeacherCourses`, `resolveCourseID`, etc.).
+
+### 2. Replaced inline closure in `project_task.go`
+
+Before (12-line inline closure):
+```go
+var projectTaskCmd = &cobra.Command{
+    Use:   "task",
+    Short: "Manage project tasks (manager role)",
+    PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+        if err := rootCmd.PersistentPreRunE(cmd, args); err != nil {
+            return err
+        }
+        cfg, err := config.Load()
+        // ... 8 more lines ...
+    },
+}
+```
+
+After:
+```go
+var projectTaskCmd = &cobra.Command{
+    Use:               "task",
+    Short:             "Manage project tasks (manager role)",
+    PersistentPreRunE: jwtAuthPreRunE,
+}
+```
+
+All 4 role-based parent commands (`manager`, `teacher`, `owner`, `task`) now reference the single shared function.
+
+### 3. Added stdout output to `update` and `register`
+
+Both commands now emit `project_id` to stdout in text mode, matching `create`:
+
+```go
+fmt.Fprintf(os.Stderr, "Project updated.\n")
+if id, ok := resp["project_id"].(string); ok {
+    fmt.Printf("project_id: %s\n", id)
+}
+```
+
+This enables consistent scripting:
+```bash
+andamio project owner update --project-id "$ID" --title "New" 2>/dev/null
+# stdout: project_id: abc123
+```
+
+### 4. Cleaned up imports
+
+- `course.go`: removed `errors`, `unicode/utf8` (no longer needed)
+- `project_task.go`: removed `apierr` import (no longer needed for inline auth)
+
+## Verification
+
+- `go build ./cmd/andamio/` — passes
+- `go vet ./cmd/andamio/` — passes
+- `go test ./...` — all tests pass
+- `grep -rn "jwtAuthPreRunE" cmd/andamio/` — returns only definition in `helpers.go` and call sites, zero inline copies
+
+## Prevention
+
+### Rules for CLAUDE.md
+
+**Helper placement**: Cross-cutting helpers belong in `cmd/andamio/helpers.go`, never in domain command files. If a function is used by more than one command file, it must not be defined in a domain file.
+
+**Refactoring completeness**: After extracting a shared function, grep for the old inline pattern across the entire package. Zero matches required before the refactor is done.
+
+**Mutating command stdout contract**: Commands that create, update, delete, or register must print exactly one machine-readable identifier to stdout on success. All human-readable messages go to stderr.
+
+### Grep Patterns for Review
+
+```bash
+# Find helpers in domain files called from other files
+grep -rn "getJSON\|postJSON\|printList\|jwtAuthPreRunE" cmd/andamio/ | grep -v helpers.go | grep -v "_test.go"
+
+# Find duplicate inline auth patterns
+grep -rn "HasUserAuth\|cfg\.UserJWT" cmd/andamio/*.go
+
+# Find mutating commands missing stdout output
+grep -A5 "Project updated\|Project registered\|Project created\|Task created\|Task updated\|Task deleted" cmd/andamio/*.go
+```
+
+## Related References
+
+### Solution Documents
+- [command-structure-refactoring.md](command-structure-refactoring.md) — Earlier extraction of `printList`/`getJSON`/`postJSON` and `PersistentPreRunE` centralization
+- [cli-composability-audit-and-fix.md](cli-composability-audit-and-fix.md) — Full audit of stdout/stderr violations with prevention checklist
+- [non-interactive-cli-stdin-picker-removal.md](non-interactive-cli-stdin-picker-removal.md) — Companion doc on stdin picker removal
+
+### Related Todos
+- `018-complete-p2-jwt-auth-helper-wrong-file.md` — Tracked the `jwtAuthPreRunE` misplacement
+- `019-complete-p2-project-task-inline-jwt-duplicate.md` — Tracked the missed inline copy
+- `020-complete-p3-owner-commands-stdout-consistency.md` — Tracked the stdout inconsistency
+- `009-pending-p3-project-slug-from-list-in-wrong-file.md` — Similar placement issue in `project_task_export.go`
+
+### GitHub PRs
+- [PR #33](https://github.com/Andamio-Platform/andamio-cli/pull/33) — Where issues were found and fixed
+- [PR #15](https://github.com/Andamio-Platform/andamio-cli/pull/15) — Earlier composability gap fixes
+- [PR #26](https://github.com/Andamio-Platform/andamio-cli/pull/26) — Earlier helper extraction example

--- a/todos/018-pending-p2-jwt-auth-helper-wrong-file.md
+++ b/todos/018-pending-p2-jwt-auth-helper-wrong-file.md
@@ -1,0 +1,54 @@
+---
+status: complete
+priority: p2
+issue_id: "018"
+tags: [code-review, architecture, refactor]
+dependencies: []
+---
+
+# Move `jwtAuthPreRunE` Out of `course.go`
+
+## Problem Statement
+
+The shared `jwtAuthPreRunE` function was extracted from inline closures in `manager.go` and `teacher.go` (PR #33) but placed in `course.go`. This function is a cross-cutting auth concern used by `manager`, `teacher`, `project owner`, and should also be used by `project task`. Placing it in a domain-specific file creates misleading coupling — anyone reading `manager.go` or `project_owner.go` has to look in `course.go` to find it.
+
+As the 7-PR API coverage push continues, more command groups will reference this function, deepening the misplacement.
+
+## Findings
+
+- `jwtAuthPreRunE` defined at `cmd/andamio/course.go:122-136`
+- Referenced by: `manager.go`, `teacher.go`, `project_owner.go`
+- `project_task.go:21-35` still has an inline duplicate (see todo #019)
+- Other general-purpose helpers (`getJSON`, `postJSON`, `printList`, `truncateUTF8`) also live in `course.go` — existing debt, but this PR should not deepen it
+
+## Proposed Solutions
+
+### Option A: Create `cmd/andamio/helpers.go` (Recommended)
+Move `jwtAuthPreRunE` to a new `helpers.go` file. Optionally move other general-purpose helpers there too.
+- **Pros**: Clean separation, obvious discovery location
+- **Cons**: One more file
+- **Effort**: Small (move function, no logic change)
+- **Risk**: None
+
+### Option B: Create `cmd/andamio/auth.go`
+Dedicated file just for auth helpers.
+- **Pros**: Very clear naming
+- **Cons**: Might be overkill for one function
+- **Effort**: Small
+- **Risk**: None
+
+## Acceptance Criteria
+
+- [ ] `jwtAuthPreRunE` is not in `course.go`
+- [ ] All references (`manager.go`, `teacher.go`, `project_owner.go`, `project_task.go`) use the shared function
+- [ ] `go build` and `go vet` pass
+
+## Work Log
+
+| Date | Action | Learnings |
+|------|--------|-----------|
+| 2026-03-21 | Created from PR #33 architecture review | Cross-cutting concerns should not live in domain files |
+
+## Resources
+
+- PR #33: https://github.com/Andamio-Platform/andamio-cli/pull/33

--- a/todos/019-pending-p2-project-task-inline-jwt-duplicate.md
+++ b/todos/019-pending-p2-project-task-inline-jwt-duplicate.md
@@ -1,0 +1,44 @@
+---
+status: complete
+priority: p2
+issue_id: "019"
+tags: [code-review, refactor, consistency]
+dependencies: ["018"]
+---
+
+# Replace Inline JWT Auth in `project_task.go` with Shared `jwtAuthPreRunE`
+
+## Problem Statement
+
+PR #33 extracted `jwtAuthPreRunE` from `manager.go` and `teacher.go` but missed `project_task.go`, which still has the identical 12-line inline closure at lines 21-35. This is an incomplete refactor — three copies were consolidated but one remains.
+
+## Findings
+
+- `cmd/andamio/project_task.go:21-35` — inline closure identical to the extracted `jwtAuthPreRunE`
+- `manager.go` and `teacher.go` already use the shared function
+- The inline closure can be replaced with `PersistentPreRunE: jwtAuthPreRunE`
+- This will also allow dropping `apierr` and `config` imports from the `PersistentPreRunE` (though `project_task.go` uses them elsewhere)
+
+## Proposed Solutions
+
+### Option A: Replace inline closure (Recommended)
+Change `projectTaskCmd` to use `PersistentPreRunE: jwtAuthPreRunE`, matching `manager.go`, `teacher.go`, and `project_owner.go`.
+- **Pros**: Eliminates last duplicate, ~12 LOC removed
+- **Cons**: None
+- **Effort**: Small (1 minute)
+- **Risk**: None
+
+## Acceptance Criteria
+
+- [ ] `project_task.go` uses `jwtAuthPreRunE` instead of inline closure
+- [ ] `go build` and `go vet` pass
+
+## Work Log
+
+| Date | Action | Learnings |
+|------|--------|-----------|
+| 2026-03-21 | Created from PR #33 code simplicity + architecture review | When extracting shared functions, grep for all copies |
+
+## Resources
+
+- PR #33: https://github.com/Andamio-Platform/andamio-cli/pull/33

--- a/todos/020-pending-p3-owner-commands-stdout-consistency.md
+++ b/todos/020-pending-p3-owner-commands-stdout-consistency.md
@@ -1,0 +1,46 @@
+---
+status: complete
+priority: p3
+issue_id: "020"
+tags: [code-review, agent-native, composability]
+dependencies: []
+---
+
+# Make `update` and `register` Emit project_id to stdout in Text Mode
+
+## Problem Statement
+
+`project owner create` prints `project_id: <id>` to stdout on success (line 158), making it pipeable. But `project owner update` and `project owner register` emit nothing to stdout in text mode — only stderr messages. This is inconsistent across the three mutating commands.
+
+For `--output json` mode this doesn't matter (full response is returned), but text-mode consistency improves quick shell scripting without requiring `jq`.
+
+## Findings
+
+- `project_owner.go:157-159` — `create` prints project_id to stdout
+- `project_owner.go:217` — `update` only prints to stderr
+- `project_owner.go:270` — `register` only prints to stderr
+- The composable pattern in CLAUDE.md recommends `--output json | jq` for scripting, so this is a UX enhancement, not a blocker
+
+## Proposed Solutions
+
+### Option A: Print project_id to stdout for all three commands
+After success, print `project_id: <id>` to stdout if the API response contains it.
+- **Pros**: Consistent pattern, enables simple shell piping
+- **Cons**: Depends on API response shape
+- **Effort**: Small
+- **Risk**: None
+
+## Acceptance Criteria
+
+- [ ] `update` and `register` print project_id to stdout in text mode (if available in response)
+- [ ] `--output json` behavior unchanged
+
+## Work Log
+
+| Date | Action | Learnings |
+|------|--------|-----------|
+| 2026-03-21 | Created from PR #33 agent-native + architecture review | Mutating commands should emit key identifiers to stdout for composability |
+
+## Resources
+
+- PR #33: https://github.com/Andamio-Platform/andamio-cli/pull/33


### PR DESCRIPTION
## Summary

- Adds `andamio project owner` subcommand group with 4 commands: list, create, update, register
- Second of 7 PRs to reach 100% API endpoint coverage

## Commands added

| Command | Endpoint | Description |
|---------|----------|-------------|
| `project owner list` | `POST /v2/project/owner/projects/list` | List owned projects |
| `project owner create` | `POST /v2/project/owner/project/create` | Create project with `--title`, `--description`, `--image-url`, `--video-url`, `--category`, `--public` |
| `project owner update` | `POST /v2/project/owner/project/update` | Partial update via `Changed()` |
| `project owner register` | `POST /v2/project/owner/project/register` | Register on-chain project with off-chain metadata |

## Test plan

- [x] `go build`, `go test`, `go vet` pass
- [x] `andamio project owner --help` shows all 4 commands
- [ ] Manual: test against preprod

## Coverage progress

**Before:** 33/61 (54%) → **After:** 37/61 (61%)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)