### PR TITLE
fix: send evidence as Tiptap JSON + Blake2b-256 hash

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,8 +135,8 @@ The app URL is derived from the API URL by replacing `.api.` with `.app.` in the
 | `course student commitments` | `/v2/course/student/assignment-commitments/list` | jwt | List assignment commitments |
 | `course student commitment` | `/v2/course/student/assignment-commitment/get` | jwt | Get commitment. `--course-id`, `--module-code` |
 | `course student create` | `/v2/course/student/commitment/create` | jwt | Enroll in module. `--course-id`, `--module-code` |
-| `course student submit` | `/v2/course/student/commitment/submit` | jwt | Submit evidence. `--course-id`, `--module-code`, `--evidence` |
-| `course student update` | `/v2/course/student/commitment/update` | jwt | Update evidence. `--course-id`, `--module-code`, `--evidence` |
+| `course student submit` | `/v2/course/student/commitment/submit` | jwt | Submit evidence. `--course-id`, `--module-code`, `--evidence` or `--evidence-file` (Markdown) |
+| `course student update` | `/v2/course/student/commitment/update` | jwt | Update evidence. `--course-id`, `--module-code`, `--evidence` or `--evidence-file` (Markdown) |
 | `course student leave` | `/v2/course/student/commitment/leave` | jwt | Leave commitment. `--course-id`, `--module-code` |
 | `course student claim` | `/v2/course/student/commitment/claim` | jwt | Claim credential. `--course-id`, `--module-code` |
 
@@ -155,7 +155,7 @@ The app URL is derived from the API URL by replacing `.api.` with `.app.` in the
 | `project contributor commitments` | `/v2/project/contributor/commitments/list` | jwt | List task commitments |
 | `project contributor commitment` | `/v2/project/contributor/commitment/get` | jwt | Get commitment. `--project-id`, `--task-index` |
 | `project contributor commit` | `/v2/project/contributor/commitment/create` | jwt | Commit to task. `--project-id`, `--task-index` |
-| `project contributor update` | `/v2/project/contributor/commitment/update` | jwt | Update evidence. `--project-id`, `--task-index`, `--evidence` |
+| `project contributor update` | `/v2/project/contributor/commitment/update` | jwt | Update evidence. `--project-id`, `--task-index`, `--evidence` or `--evidence-file` (Markdown) |
 | `project contributor delete` | `/v2/project/contributor/commitment/delete` | jwt | Delete commitment. `--project-id`, `--task-index` |
 | `project task list <project-id>` | `/v2/project/manager/tasks/list` | jwt | List tasks (manager) |
 | `project task get <index> --project-id <id>` | `/v2/project/manager/tasks/list` | jwt | Get task by index (filters from list) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,7 @@ The app URL is derived from the API URL by replacing `.api.` with `.app.` in the
 | `course teacher publish-module` | `/v2/course/teacher/course-module/publish` | jwt | Publish module. `--course-id`, `--module-code` |
 | `course teacher delete-module` | `/v2/course/teacher/course-module/delete` | jwt | Delete module. `--course-id`, `--module-code` |
 | `course teacher update-module-status` | `/v2/course/teacher/course-module/update-status` | jwt | Update module status. `--course-id`, `--module-code`, `--status` |
-| `course teacher review` | `/v2/course/teacher/assignment-commitment/review` | jwt | Review commitment. `--course-id`, `--commitment-id`, `--decision`, `--feedback` |
+| `course teacher review` | `/v2/course/teacher/assignment-commitment/review` | jwt | Review commitment. `--course-id`, `--module-code`, `--participant-alias`, `--decision` (accept/refuse) |
 | `course teacher commitments` | `/v2/course/teacher/assignment-commitments/list` | jwt | List pending reviews. `--course-id` |
 | `course student courses` | `/v2/course/student/courses/list` | jwt | List enrolled courses |
 | `course student credentials` | `/v2/course/student/credentials/list` | jwt | List earned credentials |

--- a/cmd/andamio/course_student.go
+++ b/cmd/andamio/course_student.go
@@ -142,7 +142,7 @@ func init() {
 		cmd.MarkFlagRequired("module-code")
 	}
 
-	// Submit/update flags (add --evidence)
+	// Submit/update flags (add --evidence / --evidence-file)
 	for _, cmd := range []*cobra.Command{
 		courseStudentSubmitCmd,
 		courseStudentUpdateCmd,
@@ -151,8 +151,8 @@ func init() {
 		cmd.MarkFlagRequired("course-id")
 		cmd.Flags().String("module-code", "", "Module code (required)")
 		cmd.MarkFlagRequired("module-code")
-		cmd.Flags().String("evidence", "", "Evidence URL or description (required)")
-		cmd.MarkFlagRequired("evidence")
+		cmd.Flags().String("evidence", "", "Evidence text or URL (Markdown supported)")
+		cmd.Flags().String("evidence-file", "", "Path to evidence file (Markdown)")
 	}
 }
 
@@ -215,17 +215,28 @@ func runCourseStudentAction(endpoint, verb string) func(cmd *cobra.Command, args
 }
 
 // runCourseStudentSubmitOrUpdate handles submit and update which add --evidence.
+// Evidence text is converted to Tiptap JSON and a Blake2b-256 content hash is computed.
 func runCourseStudentSubmitOrUpdate(endpoint, verb string) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		courseID, _ := cmd.Flags().GetString("course-id")
 		moduleCode, _ := cmd.Flags().GetString("module-code")
-		evidence, _ := cmd.Flags().GetString("evidence")
 		isJSON := output.GetFormat() == output.FormatJSON
+
+		evidence, err := readEvidenceFlag(cmd)
+		if err != nil {
+			return err
+		}
+
+		tiptapJSON, evidenceHash, err := wrapEvidence(evidence)
+		if err != nil {
+			return fmt.Errorf("failed to format evidence: %w", err)
+		}
 
 		payload := map[string]interface{}{
 			"course_id":          courseID,
 			"course_module_code": moduleCode,
-			"evidence":           evidence,
+			"evidence":           tiptapJSON,
+			"evidence_hash":      evidenceHash,
 		}
 
 		cfg, err := config.Load()

--- a/cmd/andamio/course_student.go
+++ b/cmd/andamio/course_student.go
@@ -79,7 +79,7 @@ var courseStudentSubmitCmd = &cobra.Command{
 
 Examples:
   andamio course student submit --course-id <id> --module-code 101 --evidence "https://github.com/..."`,
-	RunE: runCourseStudentSubmitOrUpdate("/api/v2/course/student/commitment/submit", "Submitting"),
+	RunE: runCourseStudentSubmit,
 }
 
 var courseStudentUpdateCmd = &cobra.Command{
@@ -89,7 +89,7 @@ var courseStudentUpdateCmd = &cobra.Command{
 
 Examples:
   andamio course student update --course-id <id> --module-code 101 --evidence "https://github.com/..."`,
-	RunE: runCourseStudentSubmitOrUpdate("/api/v2/course/student/commitment/update", "Updating"),
+	RunE: runCourseStudentUpdate,
 }
 
 var courseStudentLeaveCmd = &cobra.Command{
@@ -214,51 +214,103 @@ func runCourseStudentAction(endpoint, verb string) func(cmd *cobra.Command, args
 	}
 }
 
-// runCourseStudentSubmitOrUpdate handles submit and update which add --evidence.
-// Evidence text is converted to Tiptap JSON and a Blake2b-256 content hash is computed.
-func runCourseStudentSubmitOrUpdate(endpoint, verb string) func(cmd *cobra.Command, args []string) error {
-	return func(cmd *cobra.Command, args []string) error {
-		courseID, _ := cmd.Flags().GetString("course-id")
-		moduleCode, _ := cmd.Flags().GetString("module-code")
-		isJSON := output.GetFormat() == output.FormatJSON
+// runCourseStudentSubmit handles evidence submission. Resolves slt_hash from module code
+// per SubmitAssignmentCommitmentV2Request schema.
+func runCourseStudentSubmit(cmd *cobra.Command, args []string) error {
+	courseID, _ := cmd.Flags().GetString("course-id")
+	moduleCode, _ := cmd.Flags().GetString("module-code")
+	isJSON := output.GetFormat() == output.FormatJSON
 
-		evidence, err := readEvidenceFlag(cmd)
-		if err != nil {
-			return err
-		}
-
-		tiptapJSON, evidenceHash, err := wrapEvidence(evidence)
-		if err != nil {
-			return fmt.Errorf("failed to format evidence: %w", err)
-		}
-
-		payload := map[string]interface{}{
-			"course_id":          courseID,
-			"course_module_code": moduleCode,
-			"evidence":           tiptapJSON,
-			"evidence_hash":      evidenceHash,
-		}
-
-		cfg, err := config.Load()
-		if err != nil {
-			return err
-		}
-
-		if !isJSON {
-			fmt.Fprintf(os.Stderr, "%s evidence for module %s...\n", verb, moduleCode)
-		}
-
-		c := client.New(cfg)
-		var resp map[string]interface{}
-		if err := c.Post(endpoint, payload, &resp); err != nil {
-			return fmt.Errorf("failed: %w", err)
-		}
-
-		if isJSON {
-			return output.PrintJSON(resp)
-		}
-
-		fmt.Fprintf(os.Stderr, "Done.\n")
-		return nil
+	evidence, err := readEvidenceFlag(cmd)
+	if err != nil {
+		return err
 	}
+
+	tiptapDoc, evidenceHash, err := wrapEvidence(evidence)
+	if err != nil {
+		return fmt.Errorf("failed to format evidence: %w", err)
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
+	c := client.New(cfg)
+
+	// Submit endpoint requires slt_hash (on-chain module identifier)
+	sltHash, err := resolveSltHash(c, courseID, moduleCode)
+	if err != nil {
+		return err
+	}
+
+	if !isJSON {
+		fmt.Fprintf(os.Stderr, "Submitting evidence for module %s...\n", moduleCode)
+	}
+
+	payload := map[string]interface{}{
+		"course_id":     courseID,
+		"slt_hash":      sltHash,
+		"evidence":      tiptapDoc,
+		"evidence_hash": evidenceHash,
+	}
+
+	var resp map[string]interface{}
+	if err := c.Post("/api/v2/course/student/commitment/submit", payload, &resp); err != nil {
+		return fmt.Errorf("failed: %w", err)
+	}
+
+	if isJSON {
+		return output.PrintJSON(resp)
+	}
+
+	fmt.Fprintf(os.Stderr, "Done.\n")
+	return nil
+}
+
+// runCourseStudentUpdate handles evidence updates per UpdateAssignmentCommitmentV2Request schema.
+func runCourseStudentUpdate(cmd *cobra.Command, args []string) error {
+	courseID, _ := cmd.Flags().GetString("course-id")
+	moduleCode, _ := cmd.Flags().GetString("module-code")
+	isJSON := output.GetFormat() == output.FormatJSON
+
+	evidence, err := readEvidenceFlag(cmd)
+	if err != nil {
+		return err
+	}
+
+	tiptapDoc, evidenceHash, err := wrapEvidence(evidence)
+	if err != nil {
+		return fmt.Errorf("failed to format evidence: %w", err)
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
+	if !isJSON {
+		fmt.Fprintf(os.Stderr, "Updating evidence for module %s...\n", moduleCode)
+	}
+
+	c := client.New(cfg)
+
+	payload := map[string]interface{}{
+		"course_id":          courseID,
+		"course_module_code": moduleCode,
+		"evidence":           tiptapDoc,
+		"evidence_hash":      evidenceHash,
+	}
+
+	var resp map[string]interface{}
+	if err := c.Post("/api/v2/course/student/commitment/update", payload, &resp); err != nil {
+		return fmt.Errorf("failed: %w", err)
+	}
+
+	if isJSON {
+		return output.PrintJSON(resp)
+	}
+
+	fmt.Fprintf(os.Stderr, "Done.\n")
+	return nil
 }

--- a/cmd/andamio/course_teacher_ops.go
+++ b/cmd/andamio/course_teacher_ops.go
@@ -49,11 +49,11 @@ Examples:
 var courseTeacherReviewCmd = &cobra.Command{
 	Use:   "review",
 	Short: "Review a student assignment commitment",
-	Long: `Review a student's assignment submission. Approve or reject with optional feedback.
+	Long: `Review a student's assignment submission. Accept or refuse.
 
 Examples:
-  andamio course teacher review --course-id <id> --commitment-id <cid> --decision approve
-  andamio course teacher review --course-id <id> --commitment-id <cid> --decision reject --feedback "Needs more detail"`,
+  andamio course teacher review --course-id <id> --module-code 101 --participant-alias student1 --decision accept
+  andamio course teacher review --course-id <id> --module-code 101 --participant-alias student1 --decision refuse`,
 	RunE: runCourseTeacherReview,
 }
 
@@ -99,11 +99,12 @@ func init() {
 	// review flags
 	courseTeacherReviewCmd.Flags().String("course-id", "", "Course ID (required)")
 	courseTeacherReviewCmd.MarkFlagRequired("course-id")
-	courseTeacherReviewCmd.Flags().String("commitment-id", "", "Commitment ID (required)")
-	courseTeacherReviewCmd.MarkFlagRequired("commitment-id")
-	courseTeacherReviewCmd.Flags().String("decision", "", "Review decision: approve or reject (required)")
+	courseTeacherReviewCmd.Flags().String("module-code", "", "Module code (required)")
+	courseTeacherReviewCmd.MarkFlagRequired("module-code")
+	courseTeacherReviewCmd.Flags().String("participant-alias", "", "Student alias (required)")
+	courseTeacherReviewCmd.MarkFlagRequired("participant-alias")
+	courseTeacherReviewCmd.Flags().String("decision", "", "Review decision: accept or refuse (required)")
 	courseTeacherReviewCmd.MarkFlagRequired("decision")
-	courseTeacherReviewCmd.Flags().String("feedback", "", "Optional feedback message")
 
 	// commitments flags
 	courseTeacherCommitmentsCmd.Flags().String("course-id", "", "Course ID (required)")
@@ -184,22 +185,20 @@ func runCourseTeacherUpdateModuleStatus(cmd *cobra.Command, args []string) error
 
 func runCourseTeacherReview(cmd *cobra.Command, args []string) error {
 	courseID, _ := cmd.Flags().GetString("course-id")
-	commitmentID, _ := cmd.Flags().GetString("commitment-id")
+	moduleCode, _ := cmd.Flags().GetString("module-code")
+	participantAlias, _ := cmd.Flags().GetString("participant-alias")
 	decision, _ := cmd.Flags().GetString("decision")
-	feedback, _ := cmd.Flags().GetString("feedback")
 	isJSON := output.GetFormat() == output.FormatJSON
 
-	if decision != "approve" && decision != "reject" {
-		return fmt.Errorf("--decision must be 'approve' or 'reject', got %q", decision)
+	if decision != "accept" && decision != "refuse" {
+		return fmt.Errorf("--decision must be 'accept' or 'refuse', got %q", decision)
 	}
 
 	payload := map[string]interface{}{
-		"course_id":     courseID,
-		"commitment_id": commitmentID,
-		"decision":      decision,
-	}
-	if feedback != "" {
-		payload["feedback"] = feedback
+		"course_id":          courseID,
+		"course_module_code": moduleCode,
+		"participant_alias":  participantAlias,
+		"decision":           decision,
 	}
 
 	cfg, err := config.Load()
@@ -208,7 +207,7 @@ func runCourseTeacherReview(cmd *cobra.Command, args []string) error {
 	}
 
 	if !isJSON {
-		fmt.Fprintf(os.Stderr, "Reviewing commitment %s: %s\n", commitmentID, decision)
+		fmt.Fprintf(os.Stderr, "Reviewing %s (module %s): %s\n", participantAlias, moduleCode, decision)
 	}
 
 	c := client.New(cfg)

--- a/cmd/andamio/evidence_test.go
+++ b/cmd/andamio/evidence_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestWrapEvidence_PlainText(t *testing.T) {
+	jsonStr, hash, err := wrapEvidence("My evidence submission")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Must be valid JSON
+	var doc map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonStr), &doc); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+
+	// Must be a Tiptap document
+	if doc["type"] != "doc" {
+		t.Errorf("expected type=doc, got %v", doc["type"])
+	}
+	content, ok := doc["content"].([]interface{})
+	if !ok || len(content) == 0 {
+		t.Fatal("expected non-empty content array")
+	}
+
+	// Hash must be 64-char hex (32 bytes = Blake2b-256)
+	if len(hash) != 64 {
+		t.Errorf("expected 64-char hex hash, got %d chars: %s", len(hash), hash)
+	}
+}
+
+func TestWrapEvidence_URL(t *testing.T) {
+	jsonStr, hash, err := wrapEvidence("https://github.com/user/repo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var doc map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonStr), &doc); err != nil {
+		t.Fatalf("not valid JSON: %v", err)
+	}
+	if doc["type"] != "doc" {
+		t.Errorf("expected type=doc, got %v", doc["type"])
+	}
+	if len(hash) != 64 {
+		t.Errorf("expected 64-char hex hash, got %d", len(hash))
+	}
+}
+
+func TestWrapEvidence_MarkdownList(t *testing.T) {
+	input := "- item 1\n- item 2\n- item 3"
+	jsonStr, _, err := wrapEvidence(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var doc map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonStr), &doc); err != nil {
+		t.Fatalf("not valid JSON: %v", err)
+	}
+
+	// Should contain a bulletList node
+	content := doc["content"].([]interface{})
+	found := false
+	for _, node := range content {
+		if m, ok := node.(map[string]interface{}); ok && m["type"] == "bulletList" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected bulletList node in output, got: %s", jsonStr)
+	}
+}
+
+func TestWrapEvidence_Unicode(t *testing.T) {
+	input := "Evidence with CJK: \u4f60\u597d and emoji"
+	jsonStr, hash, err := wrapEvidence(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var doc map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonStr), &doc); err != nil {
+		t.Fatalf("not valid JSON: %v", err)
+	}
+	if len(hash) != 64 {
+		t.Errorf("expected 64-char hash, got %d", len(hash))
+	}
+}
+
+func TestWrapEvidence_SpecialChars(t *testing.T) {
+	input := `He said "hello" and used a \ backslash`
+	jsonStr, _, err := wrapEvidence(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Must survive JSON round-trip
+	var doc map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonStr), &doc); err != nil {
+		t.Fatalf("not valid JSON: %v", err)
+	}
+}
+
+func TestWrapEvidence_Determinism(t *testing.T) {
+	input := "Deterministic evidence test"
+	_, hash1, err := wrapEvidence(input)
+	if err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	_, hash2, err := wrapEvidence(input)
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if hash1 != hash2 {
+		t.Errorf("hashes differ for same input: %s vs %s", hash1, hash2)
+	}
+}

--- a/cmd/andamio/evidence_test.go
+++ b/cmd/andamio/evidence_test.go
@@ -6,15 +6,9 @@ import (
 )
 
 func TestWrapEvidence_PlainText(t *testing.T) {
-	jsonStr, hash, err := wrapEvidence("My evidence submission")
+	doc, hash, err := wrapEvidence("My evidence submission")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
-	}
-
-	// Must be valid JSON
-	var doc map[string]interface{}
-	if err := json.Unmarshal([]byte(jsonStr), &doc); err != nil {
-		t.Fatalf("output is not valid JSON: %v", err)
 	}
 
 	// Must be a Tiptap document
@@ -30,18 +24,19 @@ func TestWrapEvidence_PlainText(t *testing.T) {
 	if len(hash) != 64 {
 		t.Errorf("expected 64-char hex hash, got %d chars: %s", len(hash), hash)
 	}
+
+	// Must survive JSON round-trip
+	if _, err := json.Marshal(doc); err != nil {
+		t.Fatalf("document is not JSON-serializable: %v", err)
+	}
 }
 
 func TestWrapEvidence_URL(t *testing.T) {
-	jsonStr, hash, err := wrapEvidence("https://github.com/user/repo")
+	doc, hash, err := wrapEvidence("https://github.com/user/repo")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	var doc map[string]interface{}
-	if err := json.Unmarshal([]byte(jsonStr), &doc); err != nil {
-		t.Fatalf("not valid JSON: %v", err)
-	}
 	if doc["type"] != "doc" {
 		t.Errorf("expected type=doc, got %v", doc["type"])
 	}
@@ -52,18 +47,16 @@ func TestWrapEvidence_URL(t *testing.T) {
 
 func TestWrapEvidence_MarkdownList(t *testing.T) {
 	input := "- item 1\n- item 2\n- item 3"
-	jsonStr, _, err := wrapEvidence(input)
+	doc, _, err := wrapEvidence(input)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	var doc map[string]interface{}
-	if err := json.Unmarshal([]byte(jsonStr), &doc); err != nil {
-		t.Fatalf("not valid JSON: %v", err)
-	}
-
 	// Should contain a bulletList node
-	content := doc["content"].([]interface{})
+	content, ok := doc["content"].([]interface{})
+	if !ok {
+		t.Fatal("expected content array")
+	}
 	found := false
 	for _, node := range content {
 		if m, ok := node.(map[string]interface{}); ok && m["type"] == "bulletList" {
@@ -72,20 +65,20 @@ func TestWrapEvidence_MarkdownList(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Errorf("expected bulletList node in output, got: %s", jsonStr)
+		jsonBytes, _ := json.Marshal(doc)
+		t.Errorf("expected bulletList node in output, got: %s", string(jsonBytes))
 	}
 }
 
 func TestWrapEvidence_Unicode(t *testing.T) {
 	input := "Evidence with CJK: \u4f60\u597d and emoji"
-	jsonStr, hash, err := wrapEvidence(input)
+	doc, hash, err := wrapEvidence(input)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	var doc map[string]interface{}
-	if err := json.Unmarshal([]byte(jsonStr), &doc); err != nil {
-		t.Fatalf("not valid JSON: %v", err)
+	if doc["type"] != "doc" {
+		t.Errorf("expected type=doc, got %v", doc["type"])
 	}
 	if len(hash) != 64 {
 		t.Errorf("expected 64-char hash, got %d", len(hash))
@@ -94,15 +87,19 @@ func TestWrapEvidence_Unicode(t *testing.T) {
 
 func TestWrapEvidence_SpecialChars(t *testing.T) {
 	input := `He said "hello" and used a \ backslash`
-	jsonStr, _, err := wrapEvidence(input)
+	doc, _, err := wrapEvidence(input)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	// Must survive JSON round-trip
-	var doc map[string]interface{}
-	if err := json.Unmarshal([]byte(jsonStr), &doc); err != nil {
-		t.Fatalf("not valid JSON: %v", err)
+	jsonBytes, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("not JSON-serializable: %v", err)
+	}
+	var roundtrip map[string]interface{}
+	if err := json.Unmarshal(jsonBytes, &roundtrip); err != nil {
+		t.Fatalf("JSON round-trip failed: %v", err)
 	}
 }
 

--- a/cmd/andamio/helpers.go
+++ b/cmd/andamio/helpers.go
@@ -195,22 +195,22 @@ func hexDecodeAssetName(name string) string {
 	return s
 }
 
-// wrapEvidence converts evidence text to Tiptap JSON and computes its Blake2b-256 content hash.
+// wrapEvidence converts evidence text to a Tiptap JSON document and computes its Blake2b-256 content hash.
 // Input is treated as Markdown and converted via markdownToTiptap (supports URLs, lists, code).
-// Returns (tiptapJSONString, blake2b256HexHash, error).
-func wrapEvidence(text string) (string, string, error) {
+// Returns the Tiptap document as a map (for embedding as a JSON object in payloads) and the hex hash.
+func wrapEvidence(text string) (map[string]interface{}, string, error) {
 	tiptapDoc, err := markdownToTiptap(text, nil)
 	if err != nil {
-		return "", "", fmt.Errorf("markdown to tiptap: %w", err)
+		return nil, "", fmt.Errorf("markdown to tiptap: %w", err)
 	}
 
 	jsonBytes, err := json.Marshal(tiptapDoc)
 	if err != nil {
-		return "", "", fmt.Errorf("json marshal: %w", err)
+		return nil, "", fmt.Errorf("json marshal: %w", err)
 	}
 
 	hash := cardano.Blake2b256(jsonBytes)
-	return string(jsonBytes), hex.EncodeToString(hash), nil
+	return tiptapDoc, hex.EncodeToString(hash), nil
 }
 
 // readEvidenceFlag reads the evidence text from either --evidence or --evidence-file.

--- a/cmd/andamio/helpers.go
+++ b/cmd/andamio/helpers.go
@@ -195,8 +195,35 @@ func hexDecodeAssetName(name string) string {
 	return s
 }
 
+// normalizeForHashing normalizes a value for deterministic hashing.
+// Matches @andamio/core normalizeForHashing: sorts object keys, trims strings,
+// converts nil to null, preserves array order.
+func normalizeForHashing(v interface{}) interface{} {
+	if v == nil {
+		return nil
+	}
+	switch val := v.(type) {
+	case string:
+		return strings.TrimSpace(val)
+	case map[string]interface{}:
+		sorted := make(map[string]interface{}, len(val))
+		for k, child := range val {
+			sorted[k] = normalizeForHashing(child)
+		}
+		return sorted
+	case []interface{}:
+		out := make([]interface{}, len(val))
+		for i, child := range val {
+			out[i] = normalizeForHashing(child)
+		}
+		return out
+	default:
+		return v // numbers, booleans
+	}
+}
+
 // wrapEvidence converts evidence text to a Tiptap JSON document and computes its Blake2b-256 content hash.
-// Input is treated as Markdown and converted via markdownToTiptap (supports URLs, lists, code).
+// The hash matches @andamio/core computeCommitmentHash: normalize → JSON.stringify → Blake2b-256.
 // Returns the Tiptap document as a map (for embedding as a JSON object in payloads) and the hex hash.
 func wrapEvidence(text string) (map[string]interface{}, string, error) {
 	tiptapDoc, err := markdownToTiptap(text, nil)
@@ -204,13 +231,80 @@ func wrapEvidence(text string) (map[string]interface{}, string, error) {
 		return nil, "", fmt.Errorf("markdown to tiptap: %w", err)
 	}
 
-	jsonBytes, err := json.Marshal(tiptapDoc)
+	// Normalize to match frontend: sort keys, trim strings
+	normalized := normalizeForHashing(tiptapDoc)
+
+	jsonBytes, err := json.Marshal(normalized)
 	if err != nil {
 		return nil, "", fmt.Errorf("json marshal: %w", err)
 	}
 
 	hash := cardano.Blake2b256(jsonBytes)
-	return tiptapDoc, hex.EncodeToString(hash), nil
+	// Return the normalized doc (what the hash was computed from)
+	normalizedDoc, _ := normalized.(map[string]interface{})
+	return normalizedDoc, hex.EncodeToString(hash), nil
+}
+
+// resolveTaskHash looks up the task_hash for a given project + task index.
+// Fetches the user-visible task list and matches by task_index.
+func resolveTaskHash(c *client.Client, projectID string, taskIndex int) (string, error) {
+	body := map[string]string{"project_id": projectID}
+	var resp map[string]interface{}
+	if err := c.Post("/api/v2/project/user/tasks/list", body, &resp); err != nil {
+		return "", fmt.Errorf("failed to list tasks: %w", err)
+	}
+
+	data, ok := resp["data"].([]interface{})
+	if !ok {
+		return "", fmt.Errorf("no tasks found for project %s", projectID)
+	}
+
+	for _, item := range data {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		idx, _ := m["task_index"].(float64)
+		if int(idx) == taskIndex {
+			hash, _ := m["task_hash"].(string)
+			if hash == "" {
+				return "", fmt.Errorf("task %d has no task_hash (may not be on-chain yet)", taskIndex)
+			}
+			return hash, nil
+		}
+	}
+	return "", fmt.Errorf("task index %d not found in project %s\n\nList tasks with:\n  andamio project tasks %s --output json", taskIndex, projectID, projectID)
+}
+
+// resolveSltHash looks up the slt_hash for a given course + module code.
+// Fetches the course modules list and matches by module code.
+func resolveSltHash(c *client.Client, courseID, moduleCode string) (string, error) {
+	path := fmt.Sprintf("/api/v2/course/user/modules/%s", courseID)
+	var resp map[string]interface{}
+	if err := c.Get(path, &resp); err != nil {
+		return "", fmt.Errorf("failed to list modules: %w", err)
+	}
+
+	data, ok := resp["data"].([]interface{})
+	if !ok {
+		return "", fmt.Errorf("no modules found for course %s", courseID)
+	}
+
+	for _, item := range data {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		code, _ := m["course_module_code"].(string)
+		if code == moduleCode {
+			hash, _ := m["slt_hash"].(string)
+			if hash == "" {
+				return "", fmt.Errorf("module %s has no slt_hash (may not be on-chain yet)", moduleCode)
+			}
+			return hash, nil
+		}
+	}
+	return "", fmt.Errorf("module %s not found in course %s\n\nList modules with:\n  andamio course modules %s --output json", moduleCode, courseID, courseID)
 }
 
 // readEvidenceFlag reads the evidence text from either --evidence or --evidence-file.

--- a/cmd/andamio/helpers.go
+++ b/cmd/andamio/helpers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 	"unicode/utf8"
@@ -196,8 +197,9 @@ func hexDecodeAssetName(name string) string {
 }
 
 // normalizeForHashing normalizes a value for deterministic hashing.
-// Matches @andamio/core normalizeForHashing: sorts object keys, trims strings,
-// converts nil to null, preserves array order.
+// Primary purpose: trims whitespace from strings to match @andamio/core
+// computeCommitmentHash. Go's json.Marshal already sorts map keys alphabetically;
+// this function adds string trimming and recursive normalization.
 func normalizeForHashing(v interface{}) interface{} {
 	if v == nil {
 		return nil
@@ -279,7 +281,7 @@ func resolveTaskHash(c *client.Client, projectID string, taskIndex int) (string,
 // resolveSltHash looks up the slt_hash for a given course + module code.
 // Fetches the course modules list and matches by module code.
 func resolveSltHash(c *client.Client, courseID, moduleCode string) (string, error) {
-	path := fmt.Sprintf("/api/v2/course/user/modules/%s", courseID)
+	path := "/api/v2/course/user/modules/" + url.PathEscape(courseID)
 	var resp map[string]interface{}
 	if err := c.Get(path, &resp); err != nil {
 		return "", fmt.Errorf("failed to list modules: %w", err)

--- a/cmd/andamio/helpers.go
+++ b/cmd/andamio/helpers.go
@@ -2,12 +2,15 @@ package main
 
 import (
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"unicode/utf8"
 
 	"github.com/Andamio-Platform/andamio-cli/internal/apierr"
+	"github.com/Andamio-Platform/andamio-cli/internal/cardano"
 	"github.com/Andamio-Platform/andamio-cli/internal/client"
 	"github.com/Andamio-Platform/andamio-cli/internal/config"
 	"github.com/Andamio-Platform/andamio-cli/internal/output"
@@ -190,4 +193,46 @@ func hexDecodeAssetName(name string) string {
 		return name
 	}
 	return s
+}
+
+// wrapEvidence converts evidence text to Tiptap JSON and computes its Blake2b-256 content hash.
+// Input is treated as Markdown and converted via markdownToTiptap (supports URLs, lists, code).
+// Returns (tiptapJSONString, blake2b256HexHash, error).
+func wrapEvidence(text string) (string, string, error) {
+	tiptapDoc, err := markdownToTiptap(text, nil)
+	if err != nil {
+		return "", "", fmt.Errorf("markdown to tiptap: %w", err)
+	}
+
+	jsonBytes, err := json.Marshal(tiptapDoc)
+	if err != nil {
+		return "", "", fmt.Errorf("json marshal: %w", err)
+	}
+
+	hash := cardano.Blake2b256(jsonBytes)
+	return string(jsonBytes), hex.EncodeToString(hash), nil
+}
+
+// readEvidenceFlag reads the evidence text from either --evidence or --evidence-file.
+// The two flags are mutually exclusive; at least one must be set.
+func readEvidenceFlag(cmd *cobra.Command) (string, error) {
+	evidence, _ := cmd.Flags().GetString("evidence")
+	evidenceFile, _ := cmd.Flags().GetString("evidence-file")
+
+	if evidence != "" && evidenceFile != "" {
+		return "", fmt.Errorf("--evidence and --evidence-file are mutually exclusive")
+	}
+
+	if evidenceFile != "" {
+		data, err := os.ReadFile(evidenceFile)
+		if err != nil {
+			return "", fmt.Errorf("failed to read evidence file %s: %w", evidenceFile, err)
+		}
+		evidence = strings.TrimSpace(string(data))
+	}
+
+	if evidence == "" {
+		return "", fmt.Errorf("evidence is required: use --evidence or --evidence-file")
+	}
+	return evidence, nil
 }

--- a/cmd/andamio/project_contributor.go
+++ b/cmd/andamio/project_contributor.go
@@ -101,13 +101,13 @@ func init() {
 		cmd.MarkFlagRequired("task-index")
 	}
 
-	// Update flags (add --evidence)
+	// Update flags (add --evidence / --evidence-file)
 	projectContributorUpdateCmd.Flags().String("project-id", "", "Project ID (required)")
 	projectContributorUpdateCmd.MarkFlagRequired("project-id")
 	projectContributorUpdateCmd.Flags().String("task-index", "", "Task index (required)")
 	projectContributorUpdateCmd.MarkFlagRequired("task-index")
-	projectContributorUpdateCmd.Flags().String("evidence", "", "Evidence URL or description (required)")
-	projectContributorUpdateCmd.MarkFlagRequired("evidence")
+	projectContributorUpdateCmd.Flags().String("evidence", "", "Evidence text or URL (Markdown supported)")
+	projectContributorUpdateCmd.Flags().String("evidence-file", "", "Path to evidence file (Markdown)")
 }
 
 func runProjectContributorCommitment(cmd *cobra.Command, args []string) error {
@@ -168,16 +168,27 @@ func runProjectContributorAction(endpoint, verb string) func(cmd *cobra.Command,
 	}
 }
 
+// runProjectContributorUpdate sends evidence as Tiptap JSON with a Blake2b-256 content hash.
 func runProjectContributorUpdate(cmd *cobra.Command, args []string) error {
 	projectID, _ := cmd.Flags().GetString("project-id")
 	taskIndex, _ := cmd.Flags().GetString("task-index")
-	evidence, _ := cmd.Flags().GetString("evidence")
 	isJSON := output.GetFormat() == output.FormatJSON
 
+	evidence, err := readEvidenceFlag(cmd)
+	if err != nil {
+		return err
+	}
+
+	tiptapJSON, evidenceHash, err := wrapEvidence(evidence)
+	if err != nil {
+		return fmt.Errorf("failed to format evidence: %w", err)
+	}
+
 	payload := map[string]interface{}{
-		"project_id": projectID,
-		"task_index": taskIndex,
-		"evidence":   evidence,
+		"project_id":    projectID,
+		"task_index":    taskIndex,
+		"evidence":      tiptapJSON,
+		"evidence_hash": evidenceHash,
 	}
 
 	cfg, err := config.Load()

--- a/cmd/andamio/project_contributor.go
+++ b/cmd/andamio/project_contributor.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/Andamio-Platform/andamio-cli/internal/client"
 	"github.com/Andamio-Platform/andamio-cli/internal/config"
@@ -57,7 +58,7 @@ var projectContributorCommitCmd = &cobra.Command{
 
 Examples:
   andamio project contributor commit --project-id <id> --task-index 3`,
-	RunE: runProjectContributorAction("/api/v2/project/contributor/commitment/create", "Committing to task"),
+	RunE: runProjectContributorCommit,
 }
 
 var projectContributorUpdateCmd = &cobra.Command{
@@ -77,7 +78,7 @@ var projectContributorDeleteCmd = &cobra.Command{
 
 Examples:
   andamio project contributor delete --project-id <id> --task-index 3`,
-	RunE: runProjectContributorAction("/api/v2/project/contributor/commitment/delete", "Deleting commitment"),
+	RunE: runProjectContributorDelete,
 }
 
 func init() {
@@ -110,19 +111,40 @@ func init() {
 	projectContributorUpdateCmd.Flags().String("evidence-file", "", "Path to evidence file (Markdown)")
 }
 
-func runProjectContributorCommitment(cmd *cobra.Command, args []string) error {
+// loadClientAndResolveTask loads config, creates a client, and resolves task_hash from project_id + task_index.
+func loadClientAndResolveTask(cmd *cobra.Command) (*client.Client, string, int, error) {
 	projectID, _ := cmd.Flags().GetString("project-id")
-	taskIndex, _ := cmd.Flags().GetString("task-index")
+	taskIndexStr, _ := cmd.Flags().GetString("task-index")
+
+	taskIndex, err := strconv.Atoi(taskIndexStr)
+	if err != nil {
+		return nil, "", 0, fmt.Errorf("invalid task-index %q: must be a number", taskIndexStr)
+	}
 
 	cfg, err := config.Load()
+	if err != nil {
+		return nil, "", 0, err
+	}
+
+	c := client.New(cfg)
+	taskHash, err := resolveTaskHash(c, projectID, taskIndex)
+	if err != nil {
+		return nil, "", 0, err
+	}
+	return c, taskHash, taskIndex, nil
+}
+
+func runProjectContributorCommitment(cmd *cobra.Command, args []string) error {
+	projectID, _ := cmd.Flags().GetString("project-id")
+
+	c, taskHash, _, err := loadClientAndResolveTask(cmd)
 	if err != nil {
 		return err
 	}
 
-	c := client.New(cfg)
 	payload := map[string]string{
 		"project_id": projectID,
-		"task_index": taskIndex,
+		"task_hash":  taskHash,
 	}
 	var resp map[string]interface{}
 	if err := c.Post("/api/v2/project/contributor/commitment/get", payload, &resp); err != nil {
@@ -132,46 +154,37 @@ func runProjectContributorCommitment(cmd *cobra.Command, args []string) error {
 	return output.PrintJSON(resp)
 }
 
-// runProjectContributorAction returns a RunE for simple project-id + task-index POST commands.
-func runProjectContributorAction(endpoint, verb string) func(cmd *cobra.Command, args []string) error {
-	return func(cmd *cobra.Command, args []string) error {
-		projectID, _ := cmd.Flags().GetString("project-id")
-		taskIndex, _ := cmd.Flags().GetString("task-index")
-		isJSON := output.GetFormat() == output.FormatJSON
+func runProjectContributorCommit(cmd *cobra.Command, args []string) error {
+	isJSON := output.GetFormat() == output.FormatJSON
 
-		payload := map[string]interface{}{
-			"project_id": projectID,
-			"task_index": taskIndex,
-		}
-
-		cfg, err := config.Load()
-		if err != nil {
-			return err
-		}
-
-		if !isJSON {
-			fmt.Fprintf(os.Stderr, "%s %s...\n", verb, taskIndex)
-		}
-
-		c := client.New(cfg)
-		var resp map[string]interface{}
-		if err := c.Post(endpoint, payload, &resp); err != nil {
-			return fmt.Errorf("failed: %w", err)
-		}
-
-		if isJSON {
-			return output.PrintJSON(resp)
-		}
-
-		fmt.Fprintf(os.Stderr, "Done.\n")
-		return nil
+	c, taskHash, taskIndex, err := loadClientAndResolveTask(cmd)
+	if err != nil {
+		return err
 	}
+
+	if !isJSON {
+		fmt.Fprintf(os.Stderr, "Committing to task %d...\n", taskIndex)
+	}
+
+	payload := map[string]interface{}{
+		"task_hash": taskHash,
+	}
+
+	var resp map[string]interface{}
+	if err := c.Post("/api/v2/project/contributor/commitment/create", payload, &resp); err != nil {
+		return fmt.Errorf("failed: %w", err)
+	}
+
+	if isJSON {
+		return output.PrintJSON(resp)
+	}
+
+	fmt.Fprintf(os.Stderr, "Done.\n")
+	return nil
 }
 
 // runProjectContributorUpdate sends evidence as Tiptap JSON with a Blake2b-256 content hash.
 func runProjectContributorUpdate(cmd *cobra.Command, args []string) error {
-	projectID, _ := cmd.Flags().GetString("project-id")
-	taskIndex, _ := cmd.Flags().GetString("task-index")
 	isJSON := output.GetFormat() == output.FormatJSON
 
 	evidence, err := readEvidenceFlag(cmd)
@@ -179,28 +192,26 @@ func runProjectContributorUpdate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	tiptapJSON, evidenceHash, err := wrapEvidence(evidence)
+	tiptapDoc, evidenceHash, err := wrapEvidence(evidence)
 	if err != nil {
 		return fmt.Errorf("failed to format evidence: %w", err)
 	}
 
-	payload := map[string]interface{}{
-		"project_id":    projectID,
-		"task_index":    taskIndex,
-		"evidence":      tiptapJSON,
-		"evidence_hash": evidenceHash,
-	}
-
-	cfg, err := config.Load()
+	c, taskHash, taskIndex, err := loadClientAndResolveTask(cmd)
 	if err != nil {
 		return err
 	}
 
 	if !isJSON {
-		fmt.Fprintf(os.Stderr, "Updating commitment evidence for task %s...\n", taskIndex)
+		fmt.Fprintf(os.Stderr, "Updating commitment evidence for task %d...\n", taskIndex)
 	}
 
-	c := client.New(cfg)
+	payload := map[string]interface{}{
+		"task_hash":     taskHash,
+		"evidence":      tiptapDoc,
+		"evidence_hash": evidenceHash,
+	}
+
 	var resp map[string]interface{}
 	if err := c.Post("/api/v2/project/contributor/commitment/update", payload, &resp); err != nil {
 		return fmt.Errorf("failed to update commitment: %w", err)
@@ -211,5 +222,34 @@ func runProjectContributorUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Fprintf(os.Stderr, "Commitment updated.\n")
+	return nil
+}
+
+func runProjectContributorDelete(cmd *cobra.Command, args []string) error {
+	isJSON := output.GetFormat() == output.FormatJSON
+
+	c, taskHash, taskIndex, err := loadClientAndResolveTask(cmd)
+	if err != nil {
+		return err
+	}
+
+	if !isJSON {
+		fmt.Fprintf(os.Stderr, "Deleting commitment for task %d...\n", taskIndex)
+	}
+
+	payload := map[string]interface{}{
+		"task_hash": taskHash,
+	}
+
+	var resp map[string]interface{}
+	if err := c.Post("/api/v2/project/contributor/commitment/delete", payload, &resp); err != nil {
+		return fmt.Errorf("failed: %w", err)
+	}
+
+	if isJSON {
+		return output.PrintJSON(resp)
+	}
+
+	fmt.Fprintf(os.Stderr, "Done.\n")
 	return nil
 }

--- a/cmd/andamio/project_contributor.go
+++ b/cmd/andamio/project_contributor.go
@@ -58,7 +58,7 @@ var projectContributorCommitCmd = &cobra.Command{
 
 Examples:
   andamio project contributor commit --project-id <id> --task-index 3`,
-	RunE: runProjectContributorCommit,
+	RunE: runTaskHashAction("/api/v2/project/contributor/commitment/create", "Committing to task"),
 }
 
 var projectContributorUpdateCmd = &cobra.Command{
@@ -78,7 +78,7 @@ var projectContributorDeleteCmd = &cobra.Command{
 
 Examples:
   andamio project contributor delete --project-id <id> --task-index 3`,
-	RunE: runProjectContributorDelete,
+	RunE: runTaskHashAction("/api/v2/project/contributor/commitment/delete", "Deleting commitment"),
 }
 
 func init() {
@@ -154,33 +154,36 @@ func runProjectContributorCommitment(cmd *cobra.Command, args []string) error {
 	return output.PrintJSON(resp)
 }
 
-func runProjectContributorCommit(cmd *cobra.Command, args []string) error {
-	isJSON := output.GetFormat() == output.FormatJSON
+// runTaskHashAction returns a RunE for commands that resolve task_hash and POST with it.
+func runTaskHashAction(endpoint, verb string) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		isJSON := output.GetFormat() == output.FormatJSON
 
-	c, taskHash, taskIndex, err := loadClientAndResolveTask(cmd)
-	if err != nil {
-		return err
+		c, taskHash, taskIndex, err := loadClientAndResolveTask(cmd)
+		if err != nil {
+			return err
+		}
+
+		if !isJSON {
+			fmt.Fprintf(os.Stderr, "%s %d...\n", verb, taskIndex)
+		}
+
+		payload := map[string]interface{}{
+			"task_hash": taskHash,
+		}
+
+		var resp map[string]interface{}
+		if err := c.Post(endpoint, payload, &resp); err != nil {
+			return fmt.Errorf("failed: %w", err)
+		}
+
+		if isJSON {
+			return output.PrintJSON(resp)
+		}
+
+		fmt.Fprintf(os.Stderr, "Done.\n")
+		return nil
 	}
-
-	if !isJSON {
-		fmt.Fprintf(os.Stderr, "Committing to task %d...\n", taskIndex)
-	}
-
-	payload := map[string]interface{}{
-		"task_hash": taskHash,
-	}
-
-	var resp map[string]interface{}
-	if err := c.Post("/api/v2/project/contributor/commitment/create", payload, &resp); err != nil {
-		return fmt.Errorf("failed: %w", err)
-	}
-
-	if isJSON {
-		return output.PrintJSON(resp)
-	}
-
-	fmt.Fprintf(os.Stderr, "Done.\n")
-	return nil
 }
 
 // runProjectContributorUpdate sends evidence as Tiptap JSON with a Blake2b-256 content hash.
@@ -225,31 +228,3 @@ func runProjectContributorUpdate(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func runProjectContributorDelete(cmd *cobra.Command, args []string) error {
-	isJSON := output.GetFormat() == output.FormatJSON
-
-	c, taskHash, taskIndex, err := loadClientAndResolveTask(cmd)
-	if err != nil {
-		return err
-	}
-
-	if !isJSON {
-		fmt.Fprintf(os.Stderr, "Deleting commitment for task %d...\n", taskIndex)
-	}
-
-	payload := map[string]interface{}{
-		"task_hash": taskHash,
-	}
-
-	var resp map[string]interface{}
-	if err := c.Post("/api/v2/project/contributor/commitment/delete", payload, &resp); err != nil {
-		return fmt.Errorf("failed: %w", err)
-	}
-
-	if isJSON {
-		return output.PrintJSON(resp)
-	}
-
-	fmt.Fprintf(os.Stderr, "Done.\n")
-	return nil
-}

--- a/docs/plans/2026-03-23-fix-evidence-tiptap-json-and-hash-plan.md
+++ b/docs/plans/2026-03-23-fix-evidence-tiptap-json-and-hash-plan.md
@@ -1,0 +1,209 @@
+---
+title: "fix: Evidence submitted as hex-encoded plaintext instead of Tiptap JSON + hash"
+type: fix
+status: completed
+date: 2026-03-23
+---
+
+# fix: Evidence submitted as hex-encoded plaintext instead of Tiptap JSON + hash
+
+## Overview
+
+The CLI's evidence submission commands send raw plaintext strings to the API. The API hex-encodes this text and stores it in `evidenceHash`, leaving the `evidence` column empty. The frontend sends evidence as Tiptap JSON with a proper content hash. The CLI needs to match the frontend's behavior: wrap evidence in Tiptap JSON, compute a Blake2b-256 content hash, and send both fields.
+
+Ref: [GitHub Issue #36](https://github.com/andamio-platform/andamio-cli/issues/36)
+
+## Problem Statement
+
+Observed on staging (2026-03-22), TX `e006877c...`:
+
+```json
+{
+  "studentAlias": "badger",
+  "status": "SUBMITTED",
+  "evidence": "",
+  "evidenceHash": "4261646765722074657374696e6720666565646261636b"
+}
+```
+
+`evidenceHash` decodes to ASCII: `"Badger testing feedback"` — the raw evidence text hex-encoded, not a hash.
+
+**Root cause**: Three CLI commands send the `--evidence` flag value as a raw string. No Tiptap wrapping, no hash computation.
+
+| Command | File | Lines |
+|---------|------|-------|
+| `course student submit` | `cmd/andamio/course_student.go` | 218-253 |
+| `course student update` | `cmd/andamio/course_student.go` | 218-253 (shared handler) |
+| `project contributor update` | `cmd/andamio/project_contributor.go` | 171-204 |
+
+## Proposed Solution
+
+**Approach: Fix the REST endpoints (not TX pipeline switch).**
+
+Rationale:
+- REST endpoints exist for convenience without wallet signing. Students may not have `.skey` files.
+- Adding `--skey` to evidence submission would be a UX regression.
+- The API should accept properly formatted `evidence` (Tiptap JSON) and `evidence_hash` (hex string) in the REST payload.
+- If the REST endpoint doesn't accept `evidence_hash`, that's an API-side fix — the CLI should send the correct data regardless.
+
+**Implementation steps:**
+
+### Step 1: Export `blake2b256`
+
+Rename `blake2b256` to `Blake2b256` in `internal/cardano/sign.go:169`. Update the one internal caller at line 65. This function is general-purpose (not Cardano-specific) and already in a package the CLI imports.
+
+### Step 2: Create evidence wrapping helper
+
+In `cmd/andamio/helpers.go` (or a new `evidence.go`), add:
+
+```go
+// wrapEvidence converts evidence text to Tiptap JSON and computes its content hash.
+// Input is treated as Markdown and converted via markdownToTiptap.
+// Returns (tiptapJSONString, blake2b256HexHash, error).
+func wrapEvidence(text string) (string, string, error)
+```
+
+Logic:
+1. Call `markdownToTiptap(text, nil)` to convert evidence text (treating as Markdown — supports URLs, lists, code blocks)
+2. `json.Marshal` the Tiptap document (deterministic, compact JSON)
+3. Compute `cardano.Blake2b256(jsonBytes)` and hex-encode
+4. Return the JSON string and hex hash
+
+Using `markdownToTiptap` over a simple paragraph wrapper because:
+- Evidence often contains URLs (should become clickable links)
+- Matches `--content-file` precedent in `project task create`
+- The converter already handles all edge cases (unicode, special chars, GFM)
+
+### Step 3: Update `runCourseStudentSubmitOrUpdate`
+
+In `cmd/andamio/course_student.go:218-253`:
+
+```go
+evidence, _ := cmd.Flags().GetString("evidence")
+
+// Wrap evidence as Tiptap JSON + compute hash
+tiptapJSON, evidenceHash, err := wrapEvidence(evidence)
+if err != nil {
+    return fmt.Errorf("failed to format evidence: %w", err)
+}
+
+payload := map[string]interface{}{
+    "course_id":          courseID,
+    "course_module_code": moduleCode,
+    "evidence":           tiptapJSON,
+    "evidence_hash":      evidenceHash,
+}
+```
+
+### Step 4: Update `runProjectContributorUpdate`
+
+Same pattern in `cmd/andamio/project_contributor.go:171-204`.
+
+### Step 5: Add `--evidence-file` flag
+
+Follow the `--content-file` pattern from `project_task.go:627-642`:
+
+```go
+cmd.Flags().String("evidence-file", "", "Path to evidence file (Markdown)")
+```
+
+If set, read file contents and use as evidence text (mutually exclusive with `--evidence`). This was planned but never implemented — multi-line evidence with shell escaping is fragile.
+
+### Step 6: Unit tests
+
+In a new `cmd/andamio/evidence_test.go`:
+
+| Test case | Input | Assertion |
+|-----------|-------|-----------|
+| Plain text | `"My evidence"` | Valid Tiptap doc with paragraph node, 64-char hex hash |
+| URL | `"https://github.com/user/repo"` | Tiptap doc with link or autolink node |
+| Markdown list | `"- item 1\n- item 2"` | Tiptap doc with bulletList node |
+| Unicode | `"Evidence with emoji and CJK"` | Valid JSON, deterministic hash |
+| Special chars | `"He said \"hello\" and \\ backslash"` | Properly escaped in JSON |
+| Determinism | Same input twice | Identical hash both times |
+
+## Technical Considerations
+
+### Hash computation determinism
+
+Go's `json.Marshal` produces compact JSON with alphabetically sorted map keys. The frontend uses JavaScript's `JSON.stringify` which preserves insertion order. These produce different byte sequences for the same logical document, meaning **hashes will not match cross-platform**.
+
+This is acceptable: the hash is stored alongside the content for integrity checking, not for cross-platform verification. Each submission computes and stores its own hash. If cross-platform hash matching becomes required later, both sides need to agree on a canonical serialization (e.g., JCS — JSON Canonicalization Scheme).
+
+### API contract uncertainty
+
+The REST endpoints' exact field names need verification. The plan assumes `evidence` (Tiptap JSON string) and `evidence_hash` (hex string), snake_case. If the API uses different names:
+
+```bash
+# Verify by inspecting OpenAPI spec
+andamio spec fetch && jq '.paths["/api/v2/course/student/commitment/submit"]' openapi.json
+
+# Or test directly
+curl -X POST https://preprod.api.andamio.io/api/v2/course/student/commitment/submit \
+  -H "Authorization: Bearer $JWT" \
+  -d '{"course_id":"test","course_module_code":"test","evidence":"{}","evidence_hash":"abc"}'
+```
+
+### Pre-formatted Tiptap JSON passthrough
+
+If `--evidence` value is already valid Tiptap JSON (`{"type":"doc","content":[...]}`), should we detect and pass through? **Decision: No.** Always convert. The evidence commands are the convenience layer. Users with pre-formatted Tiptap can use the raw API via `tx run` or direct HTTP.
+
+### Existing broken evidence data
+
+Evidence submitted with older CLI versions has hex-encoded plaintext in `evidenceHash` and empty `evidence`. Fix does NOT include data migration. Teachers can ask students to re-submit via `course student update` after upgrading. Release notes should mention this.
+
+## System-Wide Impact
+
+- **API surface parity**: Three commands affected (`course student submit`, `course student update`, `project contributor update`). All use the same wrapping logic.
+- **Error propagation**: `markdownToTiptap` errors bubble up as `"failed to format evidence"`. No silent failures.
+- **State lifecycle risks**: None — this is a payload formatting fix, not a state change. The API handles persistence.
+- **Integration test scenarios**: Submit evidence via CLI, verify `evidence` column contains valid Tiptap JSON and `evidenceHash` contains a 64-char hex hash (not hex-encoded plaintext).
+
+## Acceptance Criteria
+
+- [x] `course student submit --evidence "text"` sends Tiptap JSON in `evidence` field
+- [x] `course student submit --evidence "text"` sends Blake2b-256 hex hash in `evidence_hash` field
+- [x] `course student update` — same behavior
+- [x] `project contributor update --evidence "text"` — same behavior
+- [x] `--evidence-file path.md` reads file and converts Markdown to Tiptap JSON
+- [x] `--evidence` and `--evidence-file` are mutually exclusive
+- [x] `blake2b256` exported as `Blake2b256` from `internal/cardano`
+- [x] Unit tests for `wrapEvidence`: plain text, URL, markdown, unicode, determinism
+- [x] `--output json` returns full API response (no change to output contract)
+- [x] Existing commands without evidence (`course student create`, `leave`, `claim`) unchanged
+
+## Success Metrics
+
+- Evidence submitted via CLI is visible in the teacher assessment UI (not hex gibberish)
+- `evidenceHash` contains a proper 64-char Blake2b-256 hex hash
+- `evidence` column contains valid Tiptap JSON document
+
+## Dependencies & Risks
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| API rejects `evidence_hash` field | Medium | Verify via OpenAPI spec or test call before implementing. If rejected, file API issue. |
+| Hash doesn't match frontend computation | Low | Acceptable — hash is stored per-submission, not verified cross-platform |
+| `markdownToTiptap` edge case on short evidence | Low | Unit tests cover plain text, URLs, lists |
+| Existing broken data confuses teachers | Medium | Document in release notes, recommend re-submit |
+
+## Sources & References
+
+### Internal References
+- Current evidence handler: `cmd/andamio/course_student.go:218-253`
+- Project contributor handler: `cmd/andamio/project_contributor.go:171-204`
+- `blake2b256` function: `internal/cardano/sign.go:169-173`
+- `markdownToTiptap` converter: `cmd/andamio/course_import.go:652`
+- TX metadata pattern: `cmd/andamio/tx_run.go:298-300`
+- `--content-file` precedent: `cmd/andamio/project_task.go:627-642`
+
+### Learnings Applied
+- `docs/solutions/feature-implementations/cli-course-import-markdown-to-tiptap-conversion.md` — Tiptap node mapping, GFM extension requirement
+- `docs/solutions/security-issues/tx-signing-code-review-witness-drop-url-validation.md` — Never silently discard errors
+
+### External References
+- Frontend reference: `andamio-app-v2/src/components/tx/task-commit.tsx` (from issue #36)
+- Staging TX: `e006877c7e6c0e800fce9054781eda79b715151a95fe5f9f139808c0f4d823e2`
+
+### Related Work
+- GitHub Issue: #36

--- a/internal/cardano/sign.go
+++ b/internal/cardano/sign.go
@@ -62,7 +62,7 @@ func SignTransaction(unsignedCBORHex string, privKey ed25519.PrivateKey, pubKey 
 	}
 
 	// Hash body with Blake2b-256
-	bodyHash := blake2b256(bodyBytes)
+	bodyHash := Blake2b256(bodyBytes)
 
 	// Sign the hash
 	signature := ed25519.Sign(privKey, bodyHash)
@@ -165,8 +165,8 @@ func assembleSignedTx(txBytes []byte, pubKey ed25519.PublicKey, signature []byte
 	return cbor.Marshal(rawElements)
 }
 
-// blake2b256 computes the Blake2b-256 hash of data.
-func blake2b256(data []byte) []byte {
+// Blake2b256 computes the Blake2b-256 hash of data.
+func Blake2b256(data []byte) []byte {
 	h, _ := blake2b.New256(nil) // nil key = unkeyed hash, never errors
 	h.Write(data)
 	return h.Sum(nil)

--- a/internal/cardano/sign_test.go
+++ b/internal/cardano/sign_test.go
@@ -80,11 +80,11 @@ func TestExtractRawArrayElement_InvalidCBOR(t *testing.T) {
 
 func TestBlake2b256(t *testing.T) {
 	// Known test vector: empty input
-	hash := blake2b256([]byte{})
+	hash := Blake2b256([]byte{})
 	expected := "0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8"
 	got := hex.EncodeToString(hash)
 	if got != expected {
-		t.Errorf("blake2b256 of empty input\n  got:  %s\n  want: %s", got, expected)
+		t.Errorf("Blake2b256 of empty input\n  got:  %s\n  want: %s", got, expected)
 	}
 
 	// Verify hash is 32 bytes


### PR DESCRIPTION
## Summary

Fixes #36 — evidence was submitted as raw plaintext, causing the API to store hex-encoded text in `evidenceHash` with an empty `evidence` column.

- **Wrap evidence as Tiptap JSON** via `markdownToTiptap` (supports URLs, lists, code blocks)
- **Compute Blake2b-256 content hash** with `normalizeForHashing` matching `@andamio/core computeCommitmentHash`
- **Add `--evidence-file` flag** for file-based evidence input (Markdown)
- **Export `Blake2b256`** from `internal/cardano` for reuse
- **Align API payloads with spec** — resolve `task_hash` and `slt_hash` via lookups, fix teacher review fields

### Commands affected
- `course student submit` — evidence as Tiptap JSON + hash, resolves `slt_hash`
- `course student update` — evidence as Tiptap JSON + hash
- `project contributor update` — evidence as Tiptap JSON + hash, resolves `task_hash`
- `project contributor commit/delete/commitment` — resolves `task_hash` (transparent)
- `course teacher review` — **breaking flag changes** (see below)

## Breaking Changes

### `course teacher review`

| Before | After |
|--------|-------|
| `--commitment-id` | `--module-code` + `--participant-alias` |
| `--decision approve` | `--decision accept` |
| `--decision reject` | `--decision refuse` |
| `--feedback "text"` | removed |

These changes align with `ReviewAssignmentCommitmentV2Request` in the API spec.

## Test plan

- [x] All 6 `wrapEvidence` unit tests pass
- [x] All existing tests pass (`go test ./...`)
- [x] Binary builds cleanly
- [ ] Manual: submit evidence via CLI, verify `evidence` column has Tiptap JSON
- [ ] Verify API accepts `evidence_hash` field

## Post-Deploy Monitoring

- **What to monitor**: staging DB evidence submissions — `evidence` column should contain valid JSON, `evidenceHash` should be 64-char hex
- **Failure signal**: `evidence` column still empty after CLI submission
- **Validation window**: First submission after deploy

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)