### PR TITLE
feat: on-chain commitment commands with evidence (#38)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,7 @@ The app URL is derived from the API URL by replacing `.api.` with `.app.` in the
 | `course student update` | `/v2/course/student/commitment/update` | jwt | Update evidence. `--course-id`, `--module-code`, `--evidence` or `--evidence-file` (Markdown) |
 | `course student leave` | `/v2/course/student/commitment/leave` | jwt | Leave commitment. `--course-id`, `--module-code` |
 | `course student claim` | `/v2/course/student/commitment/claim` | jwt | Claim credential. `--course-id`, `--module-code` |
+| `course student commit-tx` | `/v2/tx/course/student/assignment/commit` | jwt+skey | On-chain commitment with evidence. `--course-id`, `--module-code`, `--skey`, `--evidence`/`--evidence-file` (optional) |
 
 ### project — Project data
 | Command | Endpoint | Auth | Description |
@@ -157,6 +158,7 @@ The app URL is derived from the API URL by replacing `.api.` with `.app.` in the
 | `project contributor commit` | `/v2/project/contributor/commitment/create` | jwt | Commit to task. `--project-id`, `--task-index` |
 | `project contributor update` | `/v2/project/contributor/commitment/update` | jwt | Update evidence. `--project-id`, `--task-index`, `--evidence` or `--evidence-file` (Markdown) |
 | `project contributor delete` | `/v2/project/contributor/commitment/delete` | jwt | Delete commitment. `--project-id`, `--task-index` |
+| `project contributor commit-tx` | `/v2/tx/project/contributor/task/commit` | jwt+skey | On-chain commitment with evidence. `--project-id`, `--task-index`, `--skey`, `--evidence`/`--evidence-file` (optional) |
 | `project task list <project-id>` | `/v2/project/manager/tasks/list` | jwt | List tasks (manager) |
 | `project task get <index> --project-id <id>` | `/v2/project/manager/tasks/list` | jwt | Get task by index (filters from list) |
 | `project task create <project-id>` | `/v2/project/manager/task/create` | jwt | Create task. Flags: --title, --lovelace, --expiration, --github-issue |

--- a/cmd/andamio/course_student.go
+++ b/cmd/andamio/course_student.go
@@ -360,19 +360,10 @@ func runCourseStudentUpdate(cmd *cobra.Command, args []string) error {
 
 // CommitTxResult extends RunResult with domain-specific fields for commit-tx commands.
 type CommitTxResult struct {
-	TxHash        string                 `json:"tx_hash,omitempty"`
-	TxType        string                 `json:"tx_type"`
-	State         string                 `json:"state"`
-	Step          string                 `json:"step"`
-	BuildResponse map[string]interface{} `json:"build_response,omitempty"`
-	EvidenceHash  string                 `json:"evidence_hash,omitempty"`
-	SltHash       string                 `json:"slt_hash,omitempty"`
-	TaskHash      string                 `json:"task_hash,omitempty"`
-	CourseID      string                 `json:"course_id,omitempty"`
-	ModuleCode    string                 `json:"course_module_code,omitempty"`
-	ProjectID     string                 `json:"project_id,omitempty"`
-	TaskIndex     int                    `json:"task_index,omitempty"`
-	Error         string                 `json:"error,omitempty"`
+	RunResult
+	EvidenceHash string `json:"evidence_hash,omitempty"`
+	SltHash      string `json:"slt_hash,omitempty"`
+	TaskHash     string `json:"task_hash,omitempty"`
 }
 
 // runCourseStudentCommitTx handles the full on-chain assignment commitment with evidence.
@@ -419,11 +410,7 @@ func runCourseStudentCommitTx(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("failed to format evidence: %w", err)
 		}
 		if !isJSON {
-			hashPreview := evidenceHash
-			if len(hashPreview) > 16 {
-				hashPreview = hashPreview[:16] + "..."
-			}
-			fmt.Fprintf(os.Stderr, "  \u2713 Evidence hashed (blake2b-256: %s)\n", hashPreview)
+			fmt.Fprintf(os.Stderr, "  \u2713 Evidence hashed (blake2b-256: %s...)\n", evidenceHash[:16])
 		}
 	}
 
@@ -502,19 +489,12 @@ func runCourseStudentCommitTx(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Print final result in JSON mode
-	if isJSON {
+	// Print final result in JSON mode (skip if noWait already printed via executeTxLifecycle)
+	if isJSON && result.State != "registered" {
 		commitResult := CommitTxResult{
-			TxHash:        result.TxHash,
-			TxType:        result.TxType,
-			State:         result.State,
-			Step:          result.Step,
-			BuildResponse: result.BuildResponse,
-			EvidenceHash:  evidenceHash,
-			SltHash:       sltHash,
-			CourseID:      courseID,
-			ModuleCode:    moduleCode,
-			Error:         result.Error,
+			RunResult:    *result,
+			EvidenceHash: evidenceHash,
+			SltHash:      sltHash,
 		}
 		return output.PrintJSON(commitResult)
 	}
@@ -522,31 +502,3 @@ func runCourseStudentCommitTx(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// resolveContributorStateID looks up contributor_state_id from the contributor projects list.
-func resolveContributorStateID(c *client.Client, projectID string) (string, error) {
-	var resp map[string]interface{}
-	if err := c.Post("/api/v2/project/contributor/projects/list", nil, &resp); err != nil {
-		return "", fmt.Errorf("failed to list contributor projects: %w", err)
-	}
-
-	data, ok := resp["data"].([]interface{})
-	if !ok {
-		return "", fmt.Errorf("no contributor projects found")
-	}
-
-	for _, item := range data {
-		m, ok := item.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		pid, _ := m["project_id"].(string)
-		if pid == projectID {
-			csid, _ := m["contributor_state_id"].(string)
-			if csid == "" {
-				return "", fmt.Errorf("project %s has no contributor_state_id (may not be on-chain yet)", projectID)
-			}
-			return csid, nil
-		}
-	}
-	return "", fmt.Errorf("project %s not found in your contributor projects\n\nList your projects with:\n  andamio project contributor list --output json", projectID)
-}

--- a/cmd/andamio/course_student.go
+++ b/cmd/andamio/course_student.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"time"
@@ -523,20 +522,6 @@ func runCourseStudentCommitTx(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// readOptionalEvidenceFlag reads evidence if either flag is set.
-// Returns empty string and nil error if neither flag is provided.
-func readOptionalEvidenceFlag(cmd *cobra.Command) (string, bool, error) {
-	hasEvidence := cmd.Flags().Changed("evidence") || cmd.Flags().Changed("evidence-file")
-	if !hasEvidence {
-		return "", false, nil
-	}
-	evidence, err := readEvidenceFlag(cmd)
-	if err != nil {
-		return "", false, err
-	}
-	return evidence, true, nil
-}
-
 // resolveContributorStateID looks up contributor_state_id from the contributor projects list.
 func resolveContributorStateID(c *client.Client, projectID string) (string, error) {
 	var resp map[string]interface{}
@@ -564,13 +549,4 @@ func resolveContributorStateID(c *client.Client, projectID string) (string, erro
 		}
 	}
 	return "", fmt.Errorf("project %s not found in your contributor projects\n\nList your projects with:\n  andamio project contributor list --output json", projectID)
-}
-
-// marshalEvidenceForMetadata serializes the Tiptap evidence as a JSON string for metadata.
-func marshalEvidenceForMetadata(tiptapDoc map[string]interface{}) string {
-	b, err := json.Marshal(tiptapDoc)
-	if err != nil {
-		return ""
-	}
-	return string(b)
 }

--- a/cmd/andamio/course_student.go
+++ b/cmd/andamio/course_student.go
@@ -361,9 +361,10 @@ func runCourseStudentUpdate(cmd *cobra.Command, args []string) error {
 // CommitTxResult extends RunResult with domain-specific fields for commit-tx commands.
 type CommitTxResult struct {
 	RunResult
-	EvidenceHash string `json:"evidence_hash,omitempty"`
-	SltHash      string `json:"slt_hash,omitempty"`
-	TaskHash     string `json:"task_hash,omitempty"`
+	EvidenceHash  string `json:"evidence_hash,omitempty"`
+	SltHash       string `json:"slt_hash,omitempty"`
+	TaskHash      string `json:"task_hash,omitempty"`
+	OffchainError string `json:"offchain_error,omitempty"`
 }
 
 // runCourseStudentCommitTx handles the full on-chain assignment commitment with evidence.
@@ -391,11 +392,15 @@ func runCourseStudentCommitTx(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("no wallet address in config\n\nRe-login with your signing key to store your address:\n  andamio user login --skey <path> --alias <name>")
 	}
 
+	// Validate skey matches stored identity
+	warnSkeyMismatch(skeyPath, cfg, isJSON)
+
 	c := client.New(cfg)
 
 	// Prepare evidence (optional)
 	var tiptapDoc map[string]interface{}
 	var evidenceHash string
+	var offchainError string
 	hasEvidence := cmd.Flags().Changed("evidence") || cmd.Flags().Changed("evidence-file")
 	if hasEvidence {
 		evidence, err := readEvidenceFlag(cmd)
@@ -480,6 +485,7 @@ func runCourseStudentCommitTx(cmd *cobra.Command, args []string) error {
 		var offchainResp map[string]interface{}
 		if offchainErr := c.Post("/api/v2/course/student/commitment/submit", offchainPayload, &offchainResp); offchainErr != nil {
 			// Warning only — the on-chain tx is already submitted
+			offchainError = offchainErr.Error()
 			if !isJSON {
 				fmt.Fprintf(os.Stderr, "  Warning: off-chain evidence submission failed: %v\n", offchainErr)
 				fmt.Fprintf(os.Stderr, "  Recovery: andamio course student submit --course-id %s --module-code %s --evidence-file <path>\n", courseID, moduleCode)
@@ -492,9 +498,10 @@ func runCourseStudentCommitTx(cmd *cobra.Command, args []string) error {
 	// Print final result in JSON mode (skip if noWait already printed via executeTxLifecycle)
 	if isJSON && result.State != "registered" {
 		commitResult := CommitTxResult{
-			RunResult:    *result,
-			EvidenceHash: evidenceHash,
-			SltHash:      sltHash,
+			RunResult:     *result,
+			EvidenceHash:  evidenceHash,
+			SltHash:       sltHash,
+			OffchainError: offchainError,
 		}
 		return output.PrintJSON(commitResult)
 	}

--- a/cmd/andamio/course_student.go
+++ b/cmd/andamio/course_student.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/Andamio-Platform/andamio-cli/internal/client"
 	"github.com/Andamio-Platform/andamio-cli/internal/config"
@@ -112,6 +114,33 @@ Examples:
 	RunE: runCourseStudentAction("/api/v2/course/student/commitment/claim", "Claiming credential"),
 }
 
+var courseStudentCommitTxCmd = &cobra.Command{
+	Use:   "commit-tx",
+	Short: "On-chain assignment commitment with evidence",
+	Long: `Build, sign, submit, and register an on-chain assignment commitment transaction.
+
+Combines evidence preparation with the full Cardano transaction lifecycle.
+Accepts markdown evidence, converts to Tiptap JSON, computes Blake2b-256 hash,
+and uses the hash as assignment_info in the on-chain transaction.
+
+After the on-chain tx, submits evidence to the off-chain API with the pending tx hash.
+Evidence is optional — omit --evidence/--evidence-file for a commit-only transaction.
+
+Examples:
+  andamio course student commit-tx \
+    --course-id <id> --module-code 101 \
+    --evidence-file ./evidence.md --skey ./payment.skey
+
+  andamio course student commit-tx \
+    --course-id <id> --module-code 101 \
+    --evidence "See https://github.com/my/pr" --skey ./payment.skey
+
+  # Commit without evidence (enroll on-chain only)
+  andamio course student commit-tx \
+    --course-id <id> --module-code 101 --skey ./payment.skey`,
+	RunE: runCourseStudentCommitTx,
+}
+
 func init() {
 	courseCmd.AddCommand(courseStudentCmd)
 	courseStudentCmd.AddCommand(courseStudentCoursesCmd)
@@ -123,6 +152,21 @@ func init() {
 	courseStudentCmd.AddCommand(courseStudentUpdateCmd)
 	courseStudentCmd.AddCommand(courseStudentLeaveCmd)
 	courseStudentCmd.AddCommand(courseStudentClaimCmd)
+	courseStudentCmd.AddCommand(courseStudentCommitTxCmd)
+
+	// commit-tx flags
+	courseStudentCommitTxCmd.Flags().String("course-id", "", "Course ID (required)")
+	courseStudentCommitTxCmd.MarkFlagRequired("course-id")
+	courseStudentCommitTxCmd.Flags().String("module-code", "", "Module code (required)")
+	courseStudentCommitTxCmd.MarkFlagRequired("module-code")
+	courseStudentCommitTxCmd.Flags().String("skey", "", "Path to Cardano .skey file for signing (required)")
+	courseStudentCommitTxCmd.MarkFlagRequired("skey")
+	courseStudentCommitTxCmd.Flags().String("evidence", "", "Evidence text or URL (Markdown supported)")
+	courseStudentCommitTxCmd.Flags().String("evidence-file", "", "Path to evidence file (Markdown)")
+	courseStudentCommitTxCmd.Flags().String("submit-url", "", "Override submit API URL")
+	courseStudentCommitTxCmd.Flags().StringArray("submit-header", nil, "Additional submit headers (repeatable)")
+	courseStudentCommitTxCmd.Flags().Bool("no-wait", false, "Exit after registration without polling")
+	courseStudentCommitTxCmd.Flags().Duration("timeout", 10*time.Minute, "Max time to wait for confirmation")
 
 	// Commitment get flags
 	courseStudentCommitmentCmd.Flags().String("course-id", "", "Course ID (required)")
@@ -313,4 +357,220 @@ func runCourseStudentUpdate(cmd *cobra.Command, args []string) error {
 
 	fmt.Fprintf(os.Stderr, "Done.\n")
 	return nil
+}
+
+// CommitTxResult extends RunResult with domain-specific fields for commit-tx commands.
+type CommitTxResult struct {
+	TxHash        string                 `json:"tx_hash,omitempty"`
+	TxType        string                 `json:"tx_type"`
+	State         string                 `json:"state"`
+	Step          string                 `json:"step"`
+	BuildResponse map[string]interface{} `json:"build_response,omitempty"`
+	EvidenceHash  string                 `json:"evidence_hash,omitempty"`
+	SltHash       string                 `json:"slt_hash,omitempty"`
+	TaskHash      string                 `json:"task_hash,omitempty"`
+	CourseID      string                 `json:"course_id,omitempty"`
+	ModuleCode    string                 `json:"course_module_code,omitempty"`
+	ProjectID     string                 `json:"project_id,omitempty"`
+	TaskIndex     int                    `json:"task_index,omitempty"`
+	Error         string                 `json:"error,omitempty"`
+}
+
+// runCourseStudentCommitTx handles the full on-chain assignment commitment with evidence.
+func runCourseStudentCommitTx(cmd *cobra.Command, args []string) error {
+	courseID, _ := cmd.Flags().GetString("course-id")
+	moduleCode, _ := cmd.Flags().GetString("module-code")
+	skeyPath, _ := cmd.Flags().GetString("skey")
+	submitURL, _ := cmd.Flags().GetString("submit-url")
+	headers, _ := cmd.Flags().GetStringArray("submit-header")
+	noWait, _ := cmd.Flags().GetBool("no-wait")
+	timeout, _ := cmd.Flags().GetDuration("timeout")
+	isJSON := output.GetFormat() == output.FormatJSON
+
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
+	if err := checkJWTExpiry(cfg, isJSON); err != nil {
+		return err
+	}
+
+	// Require wallet address from login
+	if cfg.UserAddress == "" {
+		return fmt.Errorf("no wallet address in config\n\nRe-login with your signing key to store your address:\n  andamio user login --skey <path> --alias <name>")
+	}
+
+	c := client.New(cfg)
+
+	// Prepare evidence (optional)
+	var tiptapDoc map[string]interface{}
+	var evidenceHash string
+	hasEvidence := cmd.Flags().Changed("evidence") || cmd.Flags().Changed("evidence-file")
+	if hasEvidence {
+		evidence, err := readEvidenceFlag(cmd)
+		if err != nil {
+			return err
+		}
+		if !isJSON {
+			fmt.Fprintf(os.Stderr, "  Preparing evidence...\n")
+		}
+		tiptapDoc, evidenceHash, err = wrapEvidence(evidence)
+		if err != nil {
+			return fmt.Errorf("failed to format evidence: %w", err)
+		}
+		if !isJSON {
+			hashPreview := evidenceHash
+			if len(hashPreview) > 16 {
+				hashPreview = hashPreview[:16] + "..."
+			}
+			fmt.Fprintf(os.Stderr, "  \u2713 Evidence hashed (blake2b-256: %s)\n", hashPreview)
+		}
+	}
+
+	// Resolve slt_hash
+	sltHash, err := resolveSltHash(c, courseID, moduleCode)
+	if err != nil {
+		return err
+	}
+	if !isJSON {
+		fmt.Fprintf(os.Stderr, "  \u2713 Resolved slt_hash for module %s\n", moduleCode)
+	}
+
+	// Build the on-chain tx body
+	buildBody := map[string]interface{}{
+		"alias":     cfg.UserAlias,
+		"course_id": courseID,
+		"slt_hash":  sltHash,
+		"initiator_data": map[string]interface{}{
+			"change_address": cfg.UserAddress,
+			"used_addresses": []string{cfg.UserAddress},
+		},
+	}
+	if evidenceHash != "" {
+		buildBody["assignment_info"] = evidenceHash
+	}
+
+	// Registration metadata
+	metadata := map[string]string{
+		"slt_hash":           sltHash,
+		"course_module_code": moduleCode,
+	}
+	if evidenceHash != "" {
+		metadata["evidence_hash"] = evidenceHash
+	}
+
+	// Execute the tx lifecycle
+	result, err := executeTxLifecycle(c, cfg, TxLifecycleParams{
+		Endpoint:   "/v2/tx/course/student/assignment/commit",
+		Body:       buildBody,
+		SkeyPath:   skeyPath,
+		TxType:     "assignment_submit",
+		InstanceID: courseID,
+		Metadata:   metadata,
+		NoWait:     noWait,
+		Timeout:    timeout,
+		SubmitURL:  submitURL,
+		Headers:    headers,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Off-chain evidence submission (only if evidence was provided and we have a tx hash)
+	if hasEvidence && result.TxHash != "" {
+		if !isJSON {
+			fmt.Fprintf(os.Stderr, "  Submitting evidence to API...\n")
+		}
+
+		offchainPayload := map[string]interface{}{
+			"course_id":       courseID,
+			"slt_hash":        sltHash,
+			"evidence":        tiptapDoc,
+			"evidence_hash":   evidenceHash,
+			"pending_tx_hash": result.TxHash,
+		}
+
+		var offchainResp map[string]interface{}
+		if offchainErr := c.Post("/api/v2/course/student/commitment/submit", offchainPayload, &offchainResp); offchainErr != nil {
+			// Warning only — the on-chain tx is already submitted
+			if !isJSON {
+				fmt.Fprintf(os.Stderr, "  Warning: off-chain evidence submission failed: %v\n", offchainErr)
+				fmt.Fprintf(os.Stderr, "  Recovery: andamio course student submit --course-id %s --module-code %s --evidence-file <path>\n", courseID, moduleCode)
+			}
+		} else if !isJSON {
+			fmt.Fprintf(os.Stderr, "  \u2713 Evidence submitted to API\n")
+		}
+	}
+
+	// Print final result in JSON mode
+	if isJSON {
+		commitResult := CommitTxResult{
+			TxHash:        result.TxHash,
+			TxType:        result.TxType,
+			State:         result.State,
+			Step:          result.Step,
+			BuildResponse: result.BuildResponse,
+			EvidenceHash:  evidenceHash,
+			SltHash:       sltHash,
+			CourseID:      courseID,
+			ModuleCode:    moduleCode,
+			Error:         result.Error,
+		}
+		return output.PrintJSON(commitResult)
+	}
+
+	return nil
+}
+
+// readOptionalEvidenceFlag reads evidence if either flag is set.
+// Returns empty string and nil error if neither flag is provided.
+func readOptionalEvidenceFlag(cmd *cobra.Command) (string, bool, error) {
+	hasEvidence := cmd.Flags().Changed("evidence") || cmd.Flags().Changed("evidence-file")
+	if !hasEvidence {
+		return "", false, nil
+	}
+	evidence, err := readEvidenceFlag(cmd)
+	if err != nil {
+		return "", false, err
+	}
+	return evidence, true, nil
+}
+
+// resolveContributorStateID looks up contributor_state_id from the contributor projects list.
+func resolveContributorStateID(c *client.Client, projectID string) (string, error) {
+	var resp map[string]interface{}
+	if err := c.Post("/api/v2/project/contributor/projects/list", nil, &resp); err != nil {
+		return "", fmt.Errorf("failed to list contributor projects: %w", err)
+	}
+
+	data, ok := resp["data"].([]interface{})
+	if !ok {
+		return "", fmt.Errorf("no contributor projects found")
+	}
+
+	for _, item := range data {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		pid, _ := m["project_id"].(string)
+		if pid == projectID {
+			csid, _ := m["contributor_state_id"].(string)
+			if csid == "" {
+				return "", fmt.Errorf("project %s has no contributor_state_id (may not be on-chain yet)", projectID)
+			}
+			return csid, nil
+		}
+	}
+	return "", fmt.Errorf("project %s not found in your contributor projects\n\nList your projects with:\n  andamio project contributor list --output json", projectID)
+}
+
+// marshalEvidenceForMetadata serializes the Tiptap evidence as a JSON string for metadata.
+func marshalEvidenceForMetadata(tiptapDoc map[string]interface{}) string {
+	b, err := json.Marshal(tiptapDoc)
+	if err != nil {
+		return ""
+	}
+	return string(b)
 }

--- a/cmd/andamio/helpers.go
+++ b/cmd/andamio/helpers.go
@@ -338,6 +338,9 @@ func resolveContributorStateID(c *client.Client, projectID string) (string, erro
 	return "", fmt.Errorf("project %s not found in your contributor projects\n\nList your projects with:\n  andamio project contributor list --output json", projectID)
 }
 
+// maxEvidenceFileSize is the maximum allowed evidence file size (1 MB).
+const maxEvidenceFileSize = 1 << 20
+
 // readEvidenceFlag reads the evidence text from either --evidence or --evidence-file.
 // The two flags are mutually exclusive; at least one must be set.
 func readEvidenceFlag(cmd *cobra.Command) (string, error) {
@@ -349,6 +352,13 @@ func readEvidenceFlag(cmd *cobra.Command) (string, error) {
 	}
 
 	if evidenceFile != "" {
+		info, err := os.Stat(evidenceFile)
+		if err != nil {
+			return "", fmt.Errorf("failed to read evidence file %s: %w", evidenceFile, err)
+		}
+		if info.Size() > maxEvidenceFileSize {
+			return "", fmt.Errorf("evidence file %s is too large (%d bytes, max %d)", evidenceFile, info.Size(), maxEvidenceFileSize)
+		}
 		data, err := os.ReadFile(evidenceFile)
 		if err != nil {
 			return "", fmt.Errorf("failed to read evidence file %s: %w", evidenceFile, err)
@@ -360,4 +370,25 @@ func readEvidenceFlag(cmd *cobra.Command) (string, error) {
 		return "", fmt.Errorf("evidence is required: use --evidence or --evidence-file")
 	}
 	return evidence, nil
+}
+
+// warnSkeyMismatch loads the skey, computes its key hash, and warns if it doesn't match
+// the stored key hash from login. This catches accidental use of a mismatched signing key.
+func warnSkeyMismatch(skeyPath string, cfg *config.Config, isJSON bool) {
+	if cfg.UserKeyHash == "" {
+		return // no stored key hash to compare against
+	}
+	_, pubKey, err := cardano.LoadSigningKey(skeyPath)
+	if err != nil {
+		return // signing will fail later with a proper error
+	}
+	skeyHash := cardano.PubKeyHash(pubKey)
+	if skeyHash != cfg.UserKeyHash {
+		if !isJSON {
+			fmt.Fprintf(os.Stderr, "Warning: signing key %s does not match the authenticated user's key\n", skeyPath)
+			fmt.Fprintf(os.Stderr, "  skey key hash:  %s\n", skeyHash)
+			fmt.Fprintf(os.Stderr, "  login key hash: %s\n", cfg.UserKeyHash)
+			fmt.Fprintf(os.Stderr, "  The transaction may fail or send funds to a wrong change address.\n")
+		}
+	}
 }

--- a/cmd/andamio/helpers.go
+++ b/cmd/andamio/helpers.go
@@ -309,6 +309,35 @@ func resolveSltHash(c *client.Client, courseID, moduleCode string) (string, erro
 	return "", fmt.Errorf("module %s not found in course %s\n\nList modules with:\n  andamio course modules %s --output json", moduleCode, courseID, courseID)
 }
 
+// resolveContributorStateID looks up contributor_state_id from the contributor projects list.
+func resolveContributorStateID(c *client.Client, projectID string) (string, error) {
+	var resp map[string]interface{}
+	if err := c.Post("/api/v2/project/contributor/projects/list", nil, &resp); err != nil {
+		return "", fmt.Errorf("failed to list contributor projects: %w", err)
+	}
+
+	data, ok := resp["data"].([]interface{})
+	if !ok {
+		return "", fmt.Errorf("no contributor projects found")
+	}
+
+	for _, item := range data {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		pid, _ := m["project_id"].(string)
+		if pid == projectID {
+			csid, _ := m["contributor_state_id"].(string)
+			if csid == "" {
+				return "", fmt.Errorf("project %s has no contributor_state_id (may not be on-chain yet)", projectID)
+			}
+			return csid, nil
+		}
+	}
+	return "", fmt.Errorf("project %s not found in your contributor projects\n\nList your projects with:\n  andamio project contributor list --output json", projectID)
+}
+
 // readEvidenceFlag reads the evidence text from either --evidence or --evidence-file.
 // The two flags are mutually exclusive; at least one must be set.
 func readEvidenceFlag(cmd *cobra.Command) (string, error) {

--- a/cmd/andamio/project_contributor.go
+++ b/cmd/andamio/project_contributor.go
@@ -320,11 +320,7 @@ func runProjectContributorCommitTx(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("failed to format evidence: %w", err)
 		}
 		if !isJSON {
-			hashPreview := evidenceHash
-			if len(hashPreview) > 16 {
-				hashPreview = hashPreview[:16] + "..."
-			}
-			fmt.Fprintf(os.Stderr, "  \u2713 Evidence hashed (blake2b-256: %s)\n", hashPreview)
+			fmt.Fprintf(os.Stderr, "  \u2713 Evidence hashed (blake2b-256: %s...)\n", evidenceHash[:16])
 		}
 	}
 
@@ -393,9 +389,10 @@ func runProjectContributorCommitTx(cmd *cobra.Command, args []string) error {
 		}
 
 		offchainPayload := map[string]interface{}{
-			"task_hash":     taskHash,
-			"evidence":      tiptapDoc,
-			"evidence_hash": evidenceHash,
+			"task_hash":       taskHash,
+			"evidence":        tiptapDoc,
+			"evidence_hash":   evidenceHash,
+			"pending_tx_hash": result.TxHash,
 		}
 
 		var offchainResp map[string]interface{}
@@ -410,19 +407,12 @@ func runProjectContributorCommitTx(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Print final result in JSON mode
-	if isJSON {
+	// Print final result in JSON mode (skip if noWait already printed via executeTxLifecycle)
+	if isJSON && result.State != "registered" {
 		commitResult := CommitTxResult{
-			TxHash:        result.TxHash,
-			TxType:        result.TxType,
-			State:         result.State,
-			Step:          result.Step,
-			BuildResponse: result.BuildResponse,
-			EvidenceHash:  evidenceHash,
-			TaskHash:      taskHash,
-			ProjectID:     projectID,
-			TaskIndex:     taskIndex,
-			Error:         result.Error,
+			RunResult:    *result,
+			EvidenceHash: evidenceHash,
+			TaskHash:     taskHash,
 		}
 		return output.PrintJSON(commitResult)
 	}

--- a/cmd/andamio/project_contributor.go
+++ b/cmd/andamio/project_contributor.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/Andamio-Platform/andamio-cli/internal/client"
 	"github.com/Andamio-Platform/andamio-cli/internal/config"
@@ -81,6 +82,33 @@ Examples:
 	RunE: runTaskHashAction("/api/v2/project/contributor/commitment/delete", "Deleting commitment"),
 }
 
+var projectContributorCommitTxCmd = &cobra.Command{
+	Use:   "commit-tx",
+	Short: "On-chain task commitment with evidence",
+	Long: `Build, sign, submit, and register an on-chain task commitment transaction.
+
+Combines evidence preparation with the full Cardano transaction lifecycle.
+Accepts markdown evidence, converts to Tiptap JSON, computes Blake2b-256 hash,
+and uses the hash as task_info in the on-chain transaction.
+
+After the on-chain tx, submits evidence to the off-chain API with the pending tx hash.
+Evidence is optional — omit --evidence/--evidence-file for a commit-only transaction.
+
+Examples:
+  andamio project contributor commit-tx \
+    --project-id <id> --task-index 0 \
+    --evidence-file ./evidence.md --skey ./payment.skey
+
+  andamio project contributor commit-tx \
+    --project-id <id> --task-index 0 \
+    --evidence "See https://github.com/my/pr" --skey ./payment.skey
+
+  # Commit without evidence (on-chain only)
+  andamio project contributor commit-tx \
+    --project-id <id> --task-index 0 --skey ./payment.skey`,
+	RunE: runProjectContributorCommitTx,
+}
+
 func init() {
 	projectCmd.AddCommand(projectContributorCmd)
 	projectContributorCmd.AddCommand(projectContributorListCmd)
@@ -89,6 +117,21 @@ func init() {
 	projectContributorCmd.AddCommand(projectContributorCommitCmd)
 	projectContributorCmd.AddCommand(projectContributorUpdateCmd)
 	projectContributorCmd.AddCommand(projectContributorDeleteCmd)
+	projectContributorCmd.AddCommand(projectContributorCommitTxCmd)
+
+	// commit-tx flags
+	projectContributorCommitTxCmd.Flags().String("project-id", "", "Project ID (required)")
+	projectContributorCommitTxCmd.MarkFlagRequired("project-id")
+	projectContributorCommitTxCmd.Flags().String("task-index", "", "Task index (required)")
+	projectContributorCommitTxCmd.MarkFlagRequired("task-index")
+	projectContributorCommitTxCmd.Flags().String("skey", "", "Path to Cardano .skey file for signing (required)")
+	projectContributorCommitTxCmd.MarkFlagRequired("skey")
+	projectContributorCommitTxCmd.Flags().String("evidence", "", "Evidence text or URL (Markdown supported)")
+	projectContributorCommitTxCmd.Flags().String("evidence-file", "", "Path to evidence file (Markdown)")
+	projectContributorCommitTxCmd.Flags().String("submit-url", "", "Override submit API URL")
+	projectContributorCommitTxCmd.Flags().StringArray("submit-header", nil, "Additional submit headers (repeatable)")
+	projectContributorCommitTxCmd.Flags().Bool("no-wait", false, "Exit after registration without polling")
+	projectContributorCommitTxCmd.Flags().Duration("timeout", 10*time.Minute, "Max time to wait for confirmation")
 
 	// Shared flags for task-specific commands
 	for _, cmd := range []*cobra.Command{
@@ -225,6 +268,165 @@ func runProjectContributorUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Fprintf(os.Stderr, "Commitment updated.\n")
+	return nil
+}
+
+// runProjectContributorCommitTx handles the full on-chain task commitment with evidence.
+func runProjectContributorCommitTx(cmd *cobra.Command, args []string) error {
+	projectID, _ := cmd.Flags().GetString("project-id")
+	taskIndexStr, _ := cmd.Flags().GetString("task-index")
+	skeyPath, _ := cmd.Flags().GetString("skey")
+	submitURL, _ := cmd.Flags().GetString("submit-url")
+	headers, _ := cmd.Flags().GetStringArray("submit-header")
+	noWait, _ := cmd.Flags().GetBool("no-wait")
+	timeout, _ := cmd.Flags().GetDuration("timeout")
+	isJSON := output.GetFormat() == output.FormatJSON
+
+	taskIndex, err := strconv.Atoi(taskIndexStr)
+	if err != nil {
+		return fmt.Errorf("invalid task-index %q: must be a number", taskIndexStr)
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
+	if err := checkJWTExpiry(cfg, isJSON); err != nil {
+		return err
+	}
+
+	// Require wallet address from login
+	if cfg.UserAddress == "" {
+		return fmt.Errorf("no wallet address in config\n\nRe-login with your signing key to store your address:\n  andamio user login --skey <path> --alias <name>")
+	}
+
+	c := client.New(cfg)
+
+	// Prepare evidence (optional)
+	var tiptapDoc map[string]interface{}
+	var evidenceHash string
+	hasEvidence := cmd.Flags().Changed("evidence") || cmd.Flags().Changed("evidence-file")
+	if hasEvidence {
+		evidence, err := readEvidenceFlag(cmd)
+		if err != nil {
+			return err
+		}
+		if !isJSON {
+			fmt.Fprintf(os.Stderr, "  Preparing evidence...\n")
+		}
+		tiptapDoc, evidenceHash, err = wrapEvidence(evidence)
+		if err != nil {
+			return fmt.Errorf("failed to format evidence: %w", err)
+		}
+		if !isJSON {
+			hashPreview := evidenceHash
+			if len(hashPreview) > 16 {
+				hashPreview = hashPreview[:16] + "..."
+			}
+			fmt.Fprintf(os.Stderr, "  \u2713 Evidence hashed (blake2b-256: %s)\n", hashPreview)
+		}
+	}
+
+	// Resolve task_hash
+	taskHash, err := resolveTaskHash(c, projectID, taskIndex)
+	if err != nil {
+		return err
+	}
+	if !isJSON {
+		fmt.Fprintf(os.Stderr, "  \u2713 Resolved task_hash for task %d\n", taskIndex)
+	}
+
+	// Resolve contributor_state_id
+	contributorStateID, err := resolveContributorStateID(c, projectID)
+	if err != nil {
+		return err
+	}
+	if !isJSON {
+		fmt.Fprintf(os.Stderr, "  \u2713 Resolved contributor_state_id\n")
+	}
+
+	// Build the on-chain tx body
+	buildBody := map[string]interface{}{
+		"alias":                cfg.UserAlias,
+		"project_id":           projectID,
+		"task_hash":            taskHash,
+		"contributor_state_id": contributorStateID,
+		"initiator_data": map[string]interface{}{
+			"change_address": cfg.UserAddress,
+			"used_addresses": []string{cfg.UserAddress},
+		},
+	}
+	if evidenceHash != "" {
+		buildBody["task_info"] = evidenceHash
+	}
+
+	// Registration metadata
+	metadata := map[string]string{
+		"task_hash": taskHash,
+	}
+	if evidenceHash != "" {
+		metadata["evidence_hash"] = evidenceHash
+	}
+
+	// Execute the tx lifecycle
+	result, err := executeTxLifecycle(c, cfg, TxLifecycleParams{
+		Endpoint:   "/v2/tx/project/contributor/task/commit",
+		Body:       buildBody,
+		SkeyPath:   skeyPath,
+		TxType:     "task_submit",
+		InstanceID: projectID,
+		Metadata:   metadata,
+		NoWait:     noWait,
+		Timeout:    timeout,
+		SubmitURL:  submitURL,
+		Headers:    headers,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Off-chain evidence submission (only if evidence was provided and we have a tx hash)
+	if hasEvidence && result.TxHash != "" {
+		if !isJSON {
+			fmt.Fprintf(os.Stderr, "  Submitting evidence to API...\n")
+		}
+
+		offchainPayload := map[string]interface{}{
+			"task_hash":     taskHash,
+			"evidence":      tiptapDoc,
+			"evidence_hash": evidenceHash,
+		}
+
+		var offchainResp map[string]interface{}
+		if offchainErr := c.Post("/api/v2/project/contributor/commitment/update", offchainPayload, &offchainResp); offchainErr != nil {
+			// Warning only — the on-chain tx is already submitted
+			if !isJSON {
+				fmt.Fprintf(os.Stderr, "  Warning: off-chain evidence submission failed: %v\n", offchainErr)
+				fmt.Fprintf(os.Stderr, "  Recovery: andamio project contributor update --project-id %s --task-index %d --evidence-file <path>\n", projectID, taskIndex)
+			}
+		} else if !isJSON {
+			fmt.Fprintf(os.Stderr, "  \u2713 Evidence submitted to API\n")
+		}
+	}
+
+	// Print final result in JSON mode
+	if isJSON {
+		commitResult := CommitTxResult{
+			TxHash:        result.TxHash,
+			TxType:        result.TxType,
+			State:         result.State,
+			Step:          result.Step,
+			BuildResponse: result.BuildResponse,
+			EvidenceHash:  evidenceHash,
+			TaskHash:      taskHash,
+			ProjectID:     projectID,
+			TaskIndex:     taskIndex,
+			Error:         result.Error,
+		}
+		return output.PrintJSON(commitResult)
+	}
+
 	return nil
 }
 

--- a/cmd/andamio/project_contributor.go
+++ b/cmd/andamio/project_contributor.go
@@ -122,7 +122,7 @@ func init() {
 	// commit-tx flags
 	projectContributorCommitTxCmd.Flags().String("project-id", "", "Project ID (required)")
 	projectContributorCommitTxCmd.MarkFlagRequired("project-id")
-	projectContributorCommitTxCmd.Flags().String("task-index", "", "Task index (required)")
+	projectContributorCommitTxCmd.Flags().Int("task-index", -1, "Task index (required)")
 	projectContributorCommitTxCmd.MarkFlagRequired("task-index")
 	projectContributorCommitTxCmd.Flags().String("skey", "", "Path to Cardano .skey file for signing (required)")
 	projectContributorCommitTxCmd.MarkFlagRequired("skey")
@@ -274,18 +274,13 @@ func runProjectContributorUpdate(cmd *cobra.Command, args []string) error {
 // runProjectContributorCommitTx handles the full on-chain task commitment with evidence.
 func runProjectContributorCommitTx(cmd *cobra.Command, args []string) error {
 	projectID, _ := cmd.Flags().GetString("project-id")
-	taskIndexStr, _ := cmd.Flags().GetString("task-index")
+	taskIndex, _ := cmd.Flags().GetInt("task-index")
 	skeyPath, _ := cmd.Flags().GetString("skey")
 	submitURL, _ := cmd.Flags().GetString("submit-url")
 	headers, _ := cmd.Flags().GetStringArray("submit-header")
 	noWait, _ := cmd.Flags().GetBool("no-wait")
 	timeout, _ := cmd.Flags().GetDuration("timeout")
 	isJSON := output.GetFormat() == output.FormatJSON
-
-	taskIndex, err := strconv.Atoi(taskIndexStr)
-	if err != nil {
-		return fmt.Errorf("invalid task-index %q: must be a number", taskIndexStr)
-	}
 
 	cfg, err := config.Load()
 	if err != nil {
@@ -301,11 +296,15 @@ func runProjectContributorCommitTx(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("no wallet address in config\n\nRe-login with your signing key to store your address:\n  andamio user login --skey <path> --alias <name>")
 	}
 
+	// Validate skey matches stored identity
+	warnSkeyMismatch(skeyPath, cfg, isJSON)
+
 	c := client.New(cfg)
 
 	// Prepare evidence (optional)
 	var tiptapDoc map[string]interface{}
 	var evidenceHash string
+	var offchainError string
 	hasEvidence := cmd.Flags().Changed("evidence") || cmd.Flags().Changed("evidence-file")
 	if hasEvidence {
 		evidence, err := readEvidenceFlag(cmd)
@@ -398,6 +397,7 @@ func runProjectContributorCommitTx(cmd *cobra.Command, args []string) error {
 		var offchainResp map[string]interface{}
 		if offchainErr := c.Post("/api/v2/project/contributor/commitment/update", offchainPayload, &offchainResp); offchainErr != nil {
 			// Warning only — the on-chain tx is already submitted
+			offchainError = offchainErr.Error()
 			if !isJSON {
 				fmt.Fprintf(os.Stderr, "  Warning: off-chain evidence submission failed: %v\n", offchainErr)
 				fmt.Fprintf(os.Stderr, "  Recovery: andamio project contributor update --project-id %s --task-index %d --evidence-file <path>\n", projectID, taskIndex)
@@ -410,9 +410,10 @@ func runProjectContributorCommitTx(cmd *cobra.Command, args []string) error {
 	// Print final result in JSON mode (skip if noWait already printed via executeTxLifecycle)
 	if isJSON && result.State != "registered" {
 		commitResult := CommitTxResult{
-			RunResult:    *result,
-			EvidenceHash: evidenceHash,
-			TaskHash:     taskHash,
+			RunResult:     *result,
+			EvidenceHash:  evidenceHash,
+			TaskHash:      taskHash,
+			OffchainError: offchainError,
 		}
 		return output.PrintJSON(commitResult)
 	}

--- a/cmd/andamio/tx_lifecycle.go
+++ b/cmd/andamio/tx_lifecycle.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"sync"
+	"time"
+
+	"github.com/Andamio-Platform/andamio-cli/internal/apierr"
+	"github.com/Andamio-Platform/andamio-cli/internal/cardano"
+	"github.com/Andamio-Platform/andamio-cli/internal/client"
+	"github.com/Andamio-Platform/andamio-cli/internal/config"
+	"github.com/Andamio-Platform/andamio-cli/internal/output"
+	"github.com/Andamio-Platform/andamio-cli/internal/submit"
+)
+
+// TxLifecycleParams contains the parameters for executeTxLifecycle.
+type TxLifecycleParams struct {
+	Endpoint   string
+	Body       interface{}
+	SkeyPath   string
+	TxType     string
+	InstanceID string
+	Metadata   map[string]string
+	NoWait     bool
+	Timeout    time.Duration
+	SubmitURL  string
+	Headers    []string
+}
+
+// executeTxLifecycle runs the full Cardano transaction lifecycle:
+// build -> sign -> submit -> register -> poll.
+// It returns the RunResult with partial progress on any failure.
+func executeTxLifecycle(c *client.Client, cfg *config.Config, params TxLifecycleParams) (*RunResult, error) {
+	isJSON := output.GetFormat() == output.FormatJSON
+
+	// Resolve submit URL: params > config > error
+	submitURL := params.SubmitURL
+	if submitURL == "" {
+		submitURL = cfg.SubmitURL
+	}
+	if submitURL == "" {
+		return nil, fmt.Errorf("no submit URL configured\n\nSet one with:\n  andamio config set-submit-url <url>\n\nOr pass --submit-url <url>")
+	}
+	if err := config.ValidateSubmitURL(submitURL); err != nil {
+		return nil, err
+	}
+
+	// Set up context with SIGINT handling
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var mu sync.Mutex
+	result := &RunResult{TxType: params.TxType}
+
+	fail := func(state, msg string, origErr error) error {
+		mu.Lock()
+		result.State = state
+		result.Error = origErr.Error()
+		mu.Unlock()
+		if isJSON {
+			mu.Lock()
+			_ = output.PrintJSON(result)
+			mu.Unlock()
+			return &apierr.ReportedError{Err: fmt.Errorf("%s: %w", msg, origErr)}
+		}
+		return fmt.Errorf("%s: %w", msg, origErr)
+	}
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt)
+	defer signal.Stop(sigCh)
+	go func() {
+		<-sigCh
+		mu.Lock()
+		txHash := result.TxHash
+		mu.Unlock()
+		if txHash != "" {
+			fmt.Fprintf(os.Stderr, "\nInterrupted. Transaction may have been submitted. Check: andamio tx status %s\n", txHash)
+		}
+		cancel()
+		os.Exit(1)
+	}()
+
+	// --- Step 1: Build ---
+	mu.Lock()
+	result.Step = "build"
+	mu.Unlock()
+	if !isJSON {
+		fmt.Fprintf(os.Stderr, "  Building transaction: POST %s\n", params.Endpoint)
+	}
+
+	var buildResp map[string]interface{}
+	if err := c.Post("/api"+params.Endpoint, params.Body, &buildResp); err != nil {
+		return result, fail("build_failed", "build failed", err)
+	}
+
+	mu.Lock()
+	result.BuildResponse = buildResp
+	mu.Unlock()
+
+	unsignedTx, ok := buildResp["unsigned_tx"].(string)
+	if !ok || unsignedTx == "" {
+		return result, fail("build_failed", "build failed", fmt.Errorf("response missing unsigned_tx field"))
+	}
+
+	if !isJSON {
+		fmt.Fprintf(os.Stderr, "  \u2713 Built unsigned TX\n")
+	}
+
+	// --- Step 2: Sign ---
+	mu.Lock()
+	result.Step = "sign"
+	mu.Unlock()
+
+	privKey, pubKey, err := cardano.LoadSigningKey(params.SkeyPath)
+	if err != nil {
+		return result, fail("sign_failed", "sign failed", err)
+	}
+
+	signResult, err := cardano.SignTransaction(unsignedTx, privKey, pubKey)
+	if err != nil {
+		return result, fail("sign_failed", "sign failed", err)
+	}
+
+	mu.Lock()
+	result.TxHash = signResult.TxHash
+	mu.Unlock()
+	if !isJSON {
+		fmt.Fprintf(os.Stderr, "  \u2713 Signed with %s (tx: %s...)\n", params.SkeyPath, signResult.TxHash[:8])
+	}
+
+	// --- Step 3: Submit ---
+	mu.Lock()
+	result.Step = "submit"
+	mu.Unlock()
+	if !isJSON {
+		fmt.Fprintf(os.Stderr, "  Submitting to %s\n", submitURL)
+	}
+
+	if _, err := submit.SubmitTransaction(submitURL, signResult.SignedTx, params.Headers); err != nil {
+		if !isJSON {
+			fmt.Fprintf(os.Stderr, "  TX hash: %s\n", signResult.TxHash)
+		}
+		return result, fail("submit_failed", "submit failed (tx may be in mempool)", err)
+	}
+
+	if !isJSON {
+		fmt.Fprintf(os.Stderr, "  \u2713 Submitted to network\n")
+	}
+
+	// --- Step 4: Register ---
+	mu.Lock()
+	result.Step = "register"
+	mu.Unlock()
+
+	registerPayload := map[string]interface{}{
+		"tx_hash": signResult.TxHash,
+		"tx_type": params.TxType,
+	}
+	if params.InstanceID != "" {
+		registerPayload["instance_id"] = params.InstanceID
+	}
+	if len(params.Metadata) > 0 {
+		registerPayload["metadata"] = params.Metadata
+	}
+
+	var registerResp map[string]interface{}
+	if err := c.Post("/api/v2/tx/register", registerPayload, &registerResp); err != nil {
+		if !isJSON {
+			fmt.Fprintf(os.Stderr, "  Warning: registration failed but TX is on-chain.\n")
+			fmt.Fprintf(os.Stderr, "  TX hash: %s\n", signResult.TxHash)
+			fmt.Fprintf(os.Stderr, "  Recovery: andamio tx register --tx-hash %s --tx-type %s\n", signResult.TxHash, params.TxType)
+		}
+		return result, fail("register_failed", "register failed", err)
+	}
+
+	if !isJSON {
+		fmt.Fprintf(os.Stderr, "  \u2713 Registered as %s\n", params.TxType)
+	}
+
+	// --- Step 5: Wait for confirmation ---
+	if params.NoWait {
+		mu.Lock()
+		result.Step = "registered"
+		result.State = "registered"
+		mu.Unlock()
+		if isJSON {
+			return result, output.PrintJSON(result)
+		}
+		fmt.Fprintf(os.Stderr, "  TX hash: %s\n", signResult.TxHash)
+		fmt.Fprintf(os.Stderr, "\nNext: andamio tx status %s\n", signResult.TxHash)
+		return result, nil
+	}
+
+	mu.Lock()
+	result.Step = "polling"
+	mu.Unlock()
+	if !isJSON {
+		fmt.Fprintf(os.Stderr, "  \u23f3 Waiting for confirmation...\n")
+	}
+
+	finalState, err := pollTxStatus(ctx, c, signResult.TxHash, params.Timeout, isJSON)
+	if err != nil {
+		if !isJSON {
+			fmt.Fprintf(os.Stderr, "  TX hash: %s\n", signResult.TxHash)
+			fmt.Fprintf(os.Stderr, "\nCheck later: andamio tx status %s\n", signResult.TxHash)
+		}
+		return result, fail(finalState, "poll failed", err)
+	}
+
+	mu.Lock()
+	result.State = finalState
+	result.Step = "complete"
+	mu.Unlock()
+
+	if !isJSON {
+		fmt.Fprintf(os.Stderr, "  \u2713 Confirmed on-chain\n")
+		fmt.Fprintf(os.Stderr, "  \u2713 DB updated \u2014 complete!\n")
+	}
+
+	return result, nil
+}

--- a/cmd/andamio/tx_run.go
+++ b/cmd/andamio/tx_run.go
@@ -6,17 +6,13 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"os/signal"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/Andamio-Platform/andamio-cli/internal/apierr"
-	"github.com/Andamio-Platform/andamio-cli/internal/cardano"
 	"github.com/Andamio-Platform/andamio-cli/internal/client"
 	"github.com/Andamio-Platform/andamio-cli/internal/config"
 	"github.com/Andamio-Platform/andamio-cli/internal/output"
-	"github.com/Andamio-Platform/andamio-cli/internal/submit"
 	"github.com/spf13/cobra"
 )
 
@@ -143,217 +139,53 @@ func runTxRun(cmd *cobra.Command, args []string) error {
 	}
 
 	// JWT expiry pre-check
-	if cfg.JWTExpiresAt != "" {
-		expiresAt, err := time.Parse(time.RFC3339, cfg.JWTExpiresAt)
-		if err != nil {
-			if !isJSON {
-				fmt.Fprintf(os.Stderr, "Warning: could not parse JWT expiry %q — skipping expiry pre-check\n", cfg.JWTExpiresAt)
-			}
-		} else {
-			remaining := time.Until(expiresAt)
-			if remaining <= 0 {
-				return &apierr.AuthError{Message: "JWT has expired. Run 'andamio user login' to refresh"}
-			}
-			if remaining < 5*time.Minute && !isJSON {
-				fmt.Fprintf(os.Stderr, "Warning: JWT expires in %s — pipeline may fail at register step. Run 'andamio user login' to refresh.\n", remaining.Truncate(time.Second))
-			}
-		}
-	}
-
-	// Resolve submit URL: flag > config > error
-	if submitURL == "" {
-		submitURL = cfg.SubmitURL
-	}
-	if submitURL == "" {
-		return fmt.Errorf("no submit URL configured\n\nSet one with:\n  andamio config set-submit-url <url>\n\nOr pass --submit-url <url>")
-	}
-	if err := config.ValidateSubmitURL(submitURL); err != nil {
-		return err
-	}
-
-	// Set up context with SIGINT handling
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	var mu sync.Mutex
-	result := &RunResult{TxType: txType}
-
-	// fail prints the RunResult as JSON (if in JSON mode) and returns the appropriate error.
-	// In JSON mode it wraps the error as ReportedError so main.go sets the exit code
-	// without printing a second error message.
-	fail := func(state, msg string, origErr error) error {
-		mu.Lock()
-		result.State = state
-		result.Error = origErr.Error()
-		mu.Unlock()
-		if isJSON {
-			mu.Lock()
-			_ = output.PrintJSON(result)
-			mu.Unlock()
-			return &apierr.ReportedError{Err: fmt.Errorf("%s: %w", msg, origErr)}
-		}
-		return fmt.Errorf("%s: %w", msg, origErr)
-	}
-
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, os.Interrupt)
-	defer signal.Stop(sigCh)
-	go func() {
-		<-sigCh
-		mu.Lock()
-		txHash := result.TxHash
-		mu.Unlock()
-		// Print recovery info. In a CLI, os.Exit is necessary here because
-		// context cancellation alone cannot unblock synchronous HTTP calls
-		// in the build/sign/submit steps (the client package does not accept
-		// a context). The OS reclaims all resources on exit.
-		if txHash != "" {
-			fmt.Fprintf(os.Stderr, "\nInterrupted. Transaction may have been submitted. Check: andamio tx status %s\n", txHash)
-		}
-		cancel()
-		os.Exit(1)
-	}()
+	checkJWTExpiry(cfg, isJSON)
 
 	c := client.New(cfg)
 
-	// --- Step 1: Build ---
-	mu.Lock()
-	result.Step = "build"
-	mu.Unlock()
-	if !isJSON {
-		fmt.Fprintf(os.Stderr, "  Building transaction: POST %s\n", endpoint)
-	}
+	result, err := executeTxLifecycle(c, cfg, TxLifecycleParams{
+		Endpoint:   endpoint,
+		Body:       bodyData,
+		SkeyPath:   skeyPath,
+		TxType:     txType,
+		InstanceID: instanceID,
+		Metadata:   metadata,
+		NoWait:     noWait,
+		Timeout:    timeout,
+		SubmitURL:  submitURL,
+		Headers:    headers,
+	})
 
-	var buildResp map[string]interface{}
-	if err := c.Post("/api"+endpoint, bodyData, &buildResp); err != nil {
-		return fail("build_failed", "build failed", err)
-	}
-
-	mu.Lock()
-	result.BuildResponse = buildResp
-	mu.Unlock()
-
-	unsignedTx, ok := buildResp["unsigned_tx"].(string)
-	if !ok || unsignedTx == "" {
-		return fail("build_failed", "build failed", fmt.Errorf("response missing unsigned_tx field"))
-	}
-
-	if !isJSON {
-		fmt.Fprintf(os.Stderr, "  \u2713 Built unsigned TX\n")
-	}
-
-	// --- Step 2: Sign ---
-	mu.Lock()
-	result.Step = "sign"
-	mu.Unlock()
-
-	privKey, pubKey, err := cardano.LoadSigningKey(skeyPath)
 	if err != nil {
-		return fail("sign_failed", "sign failed", err)
+		return err
 	}
 
-	signResult, err := cardano.SignTransaction(unsignedTx, privKey, pubKey)
-	if err != nil {
-		return fail("sign_failed", "sign failed", err)
-	}
-
-	mu.Lock()
-	result.TxHash = signResult.TxHash
-	mu.Unlock()
-	if !isJSON {
-		fmt.Fprintf(os.Stderr, "  \u2713 Signed with %s (tx: %s...)\n", skeyPath, signResult.TxHash[:8])
-	}
-
-	// --- Step 3: Submit ---
-	mu.Lock()
-	result.Step = "submit"
-	mu.Unlock()
-	if !isJSON {
-		fmt.Fprintf(os.Stderr, "  Submitting to %s\n", submitURL)
-	}
-
-	if _, err := submit.SubmitTransaction(submitURL, signResult.SignedTx, headers); err != nil {
-		if !isJSON {
-			fmt.Fprintf(os.Stderr, "  TX hash: %s\n", signResult.TxHash)
-		}
-		return fail("submit_failed", "submit failed (tx may be in mempool)", err)
-	}
-
-	if !isJSON {
-		fmt.Fprintf(os.Stderr, "  \u2713 Submitted to network\n")
-	}
-
-	// --- Step 4: Register ---
-	mu.Lock()
-	result.Step = "register"
-	mu.Unlock()
-
-	registerPayload := map[string]interface{}{
-		"tx_hash": signResult.TxHash,
-		"tx_type": txType,
-	}
-	if instanceID != "" {
-		registerPayload["instance_id"] = instanceID
-	}
-	if len(metadata) > 0 {
-		registerPayload["metadata"] = metadata
-	}
-
-	var registerResp map[string]interface{}
-	if err := c.Post("/api/v2/tx/register", registerPayload, &registerResp); err != nil {
-		if !isJSON {
-			fmt.Fprintf(os.Stderr, "  Warning: registration failed but TX is on-chain.\n")
-			fmt.Fprintf(os.Stderr, "  TX hash: %s\n", signResult.TxHash)
-			fmt.Fprintf(os.Stderr, "  Recovery: andamio tx register --tx-hash %s --tx-type %s\n", signResult.TxHash, txType)
-		}
-		return fail("register_failed", "register failed", err)
-	}
-
-	if !isJSON {
-		fmt.Fprintf(os.Stderr, "  \u2713 Registered as %s\n", txType)
-	}
-
-	// --- Step 5: Wait for confirmation ---
-	if noWait {
-		mu.Lock()
-		result.Step = "registered"
-		result.State = "registered"
-		mu.Unlock()
-		if isJSON {
-			return output.PrintJSON(result)
-		}
-		fmt.Fprintf(os.Stderr, "  TX hash: %s\n", signResult.TxHash)
-		fmt.Fprintf(os.Stderr, "\nNext: andamio tx status %s\n", signResult.TxHash)
-		return nil
-	}
-
-	mu.Lock()
-	result.Step = "polling"
-	mu.Unlock()
-	if !isJSON {
-		fmt.Fprintf(os.Stderr, "  \u23f3 Waiting for confirmation...\n")
-	}
-
-	finalState, err := pollTxStatus(ctx, c, signResult.TxHash, timeout, isJSON)
-	if err != nil {
-		if !isJSON {
-			fmt.Fprintf(os.Stderr, "  TX hash: %s\n", signResult.TxHash)
-			fmt.Fprintf(os.Stderr, "\nCheck later: andamio tx status %s\n", signResult.TxHash)
-		}
-		return fail(finalState, "poll failed", err)
-	}
-
-	mu.Lock()
-	result.State = finalState
-	result.Step = "complete"
-	mu.Unlock()
-
-	if isJSON {
+	// For non-noWait success in JSON mode, print the final result
+	if isJSON && result.State != "registered" {
 		return output.PrintJSON(result)
 	}
+	return nil
+}
 
-	fmt.Fprintf(os.Stderr, "  \u2713 Confirmed on-chain\n")
-	fmt.Fprintf(os.Stderr, "  \u2713 DB updated \u2014 complete!\n")
+// checkJWTExpiry warns about or rejects expired JWTs. Returns an error only if expired.
+func checkJWTExpiry(cfg *config.Config, isJSON bool) error {
+	if cfg.JWTExpiresAt == "" {
+		return nil
+	}
+	expiresAt, err := time.Parse(time.RFC3339, cfg.JWTExpiresAt)
+	if err != nil {
+		if !isJSON {
+			fmt.Fprintf(os.Stderr, "Warning: could not parse JWT expiry %q — skipping expiry pre-check\n", cfg.JWTExpiresAt)
+		}
+		return nil
+	}
+	remaining := time.Until(expiresAt)
+	if remaining <= 0 {
+		return &apierr.AuthError{Message: "JWT has expired. Run 'andamio user login' to refresh"}
+	}
+	if remaining < 5*time.Minute && !isJSON {
+		fmt.Fprintf(os.Stderr, "Warning: JWT expires in %s — pipeline may fail at register step. Run 'andamio user login' to refresh.\n", remaining.Truncate(time.Second))
+	}
 	return nil
 }
 

--- a/cmd/andamio/tx_run.go
+++ b/cmd/andamio/tx_run.go
@@ -139,7 +139,9 @@ func runTxRun(cmd *cobra.Command, args []string) error {
 	}
 
 	// JWT expiry pre-check
-	checkJWTExpiry(cfg, isJSON)
+	if err := checkJWTExpiry(cfg, isJSON); err != nil {
+		return err
+	}
 
 	c := client.New(cfg)
 

--- a/cmd/andamio/user.go
+++ b/cmd/andamio/user.go
@@ -332,6 +332,9 @@ func runHeadlessLogin(cfg *config.Config, skeyPath, alias string) error {
 		cfg.UserAlias = alias
 	}
 	cfg.UserID = tokenResp.User.ID
+	if tokenResp.User.CardanoBech32Addr != nil {
+		cfg.UserAddress = *tokenResp.User.CardanoBech32Addr
+	}
 
 	if err := config.Save(cfg); err != nil {
 		return fmt.Errorf("failed to save config: %w", err)
@@ -341,6 +344,7 @@ func runHeadlessLogin(cfg *config.Config, skeyPath, alias string) error {
 		return output.PrintJSON(map[string]interface{}{
 			"alias":    cfg.UserAlias,
 			"user_id":  cfg.UserID,
+			"address":  cfg.UserAddress,
 			"key_hash": signResult.KeyHash,
 		})
 	}

--- a/cmd/andamio/user.go
+++ b/cmd/andamio/user.go
@@ -335,6 +335,7 @@ func runHeadlessLogin(cfg *config.Config, skeyPath, alias string) error {
 	if tokenResp.User.CardanoBech32Addr != nil {
 		cfg.UserAddress = *tokenResp.User.CardanoBech32Addr
 	}
+	cfg.UserKeyHash = signResult.KeyHash
 
 	if err := config.Save(cfg); err != nil {
 		return fmt.Errorf("failed to save config: %w", err)

--- a/docs/plans/2026-03-23-feat-onchain-commitment-commands-with-evidence-plan.md
+++ b/docs/plans/2026-03-23-feat-onchain-commitment-commands-with-evidence-plan.md
@@ -1,0 +1,373 @@
+---
+title: "feat: On-chain commitment commands with evidence for courses and projects"
+type: feat
+status: completed
+date: 2026-03-23
+origin: GitHub Issue #38
+---
+
+# On-Chain Commitment Commands with Evidence
+
+## Overview
+
+Add domain-specific commands that combine evidence preparation with the full Cardano transaction lifecycle for assignment commitments (courses) and task commitments (projects). Each command wires together existing building blocks (`wrapEvidence`, `tx run` orchestration, hash resolvers) into a single-command workflow that mirrors what the app does in `assignment-commitment.tsx`.
+
+Two new commands:
+- `course student commit-tx` -- on-chain assignment commitment with evidence
+- `project contributor commit-tx` -- on-chain task commitment with evidence
+
+Both replace a manual multi-step bash-script workflow with a single CLI invocation.
+
+## Problem Statement / Motivation
+
+The CLI has all the pieces but they aren't wired together:
+
+| Building block | Location | Status |
+|---------------|----------|--------|
+| `wrapEvidence()` (markdown -> Tiptap + Blake2b-256) | `cmd/andamio/helpers.go:230` | Exists |
+| `markdownToTiptap()` | `cmd/andamio/course_import.go:652` | Exists |
+| `readEvidenceFlag()` | `cmd/andamio/helpers.go:314` | Exists |
+| `resolveSltHash()` | `cmd/andamio/helpers.go:283` | Exists |
+| `resolveTaskHash()` | `cmd/andamio/helpers.go:252` | Exists |
+| `tx run` lifecycle (build->sign->submit->register->poll) | `cmd/andamio/tx_run.go` | Exists |
+| `cardano.LoadSigningKey()` + `SignTransaction()` | `internal/cardano/sign.go` | Exists |
+
+Today, users must: (1) convert evidence to Tiptap JSON, (2) compute Blake2b-256 hash, (3) construct a complex `--body` JSON with the hash as `assignment_info`, (4) pass evidence as `--metadata` on `tx run`. A bash script with embedded Python (`040-testing/xp/preprod/assignment-commit.sh` in orch) fills this gap. That script reimplements logic already in the CLI's Go code.
+
+## Proposed Solution
+
+### Command 1: `course student commit-tx`
+
+Single command for on-chain assignment commitment with evidence. Two-phase: on-chain tx + off-chain evidence storage.
+
+```bash
+andamio course student commit-tx \
+  --course-id abc123... \
+  --module-code 101 \
+  --evidence-file ./my-evidence.md \
+  --skey ./payment.skey
+```
+
+**Flags:**
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--course-id` | yes | Course policy ID |
+| `--module-code` | yes | Human-readable module code |
+| `--evidence` | one of | Inline markdown evidence |
+| `--evidence-file` | one of | Path to markdown evidence file |
+| `--skey` | yes | Path to `.skey` file for signing |
+| `--submit-url` | no | Override submit API URL |
+| `--submit-header` | no | Additional submit headers (repeatable) |
+| `--no-wait` | no | Exit after registration |
+| `--timeout` | no | Max poll time (default 10m) |
+
+**Execution flow:**
+
+```
+1. readEvidenceFlag(cmd)                    -> raw markdown string
+2. wrapEvidence(raw)                        -> tiptapDoc, evidenceHash
+3. Load config, create client
+4. resolveSltHash(c, courseID, moduleCode)   -> sltHash
+5. Resolve wallet address (see "Address Resolution" below)
+6. Construct build body:
+   {
+     "alias":           cfg.UserAlias,
+     "assignment_info": evidenceHash,       // 64-char hex, fits 140-char limit
+     "course_id":       courseID,
+     "slt_hash":        sltHash,
+     "initiator_data": {
+       "change_address": address,
+       "used_addresses": [address]
+     }
+   }
+7. POST /v2/tx/course/student/assignment/commit -> unsigned_tx
+8. Sign with .skey                              -> signed_tx, tx_hash
+9. Submit to Cardano network
+10. Register as tx_type="assignment_submit", instance_id=courseID
+    metadata: { slt_hash, course_module_code, evidence_hash }
+11. Off-chain evidence submission:
+    POST /api/v2/course/student/commitment/submit
+    {
+      "course_id":      courseID,
+      "slt_hash":       sltHash,
+      "evidence":       tiptapDoc,          // Tiptap JSON object
+      "evidence_hash":  evidenceHash,
+      "pending_tx_hash": txHash
+    }
+12. Poll for on-chain confirmation (unless --no-wait)
+```
+
+**Output (stderr, text mode):**
+```
+  Preparing evidence...
+  ✓ Evidence hashed (blake2b-256: abc123...)
+  ✓ Resolved slt_hash for module 101
+  ✓ Built unsigned TX
+  ✓ Signed with payment.skey
+  ✓ Submitted to network (tx: def456...)
+  ✓ Registered as assignment_submit
+  ✓ Evidence submitted to API
+  ⏳ Waiting for confirmation...
+  ✓ Confirmed on-chain
+  ✓ DB updated — complete!
+```
+
+**Output (--output json):**
+```json
+{
+  "tx_hash": "def456...",
+  "tx_type": "assignment_submit",
+  "state": "updated",
+  "step": "complete",
+  "evidence_hash": "abc123...",
+  "slt_hash": "...",
+  "course_id": "...",
+  "course_module_code": "101"
+}
+```
+
+### Command 2: `project contributor commit-tx`
+
+Parallel implementation for on-chain task commitment with evidence.
+
+```bash
+andamio project contributor commit-tx \
+  --project-id abc123... \
+  --task-index 0 \
+  --evidence-file ./my-evidence.md \
+  --skey ./payment.skey
+```
+
+**Flags:** Same pattern, with `--project-id` and `--task-index` replacing `--course-id` and `--module-code`.
+
+**Execution flow:**
+
+```
+1-2. Same evidence preparation
+3.   Load config, create client
+4.   resolveTaskHash(c, projectID, taskIndex)  -> taskHash
+5.   Resolve contributor_state_id (see below)
+6.   Construct build body:
+     {
+       "alias":                cfg.UserAlias,
+       "task_info":            evidenceHash,
+       "project_id":           projectID,
+       "task_hash":            taskHash,
+       "contributor_state_id": contributorStateID,
+       "initiator_data": {
+         "change_address": address,
+         "used_addresses": [address]
+       }
+     }
+7.   POST /v2/tx/project/contributor/task/commit -> unsigned_tx
+8-10. Sign, submit, register as tx_type="task_submit", instance_id=projectID
+11.  Off-chain: POST /api/v2/project/contributor/commitment/update
+     { "task_hash": taskHash, "evidence": tiptapDoc, "evidence_hash": evidenceHash }
+12.  Poll for confirmation
+```
+
+## Technical Considerations
+
+### Address Resolution (Critical -- Blocks Both Commands)
+
+The build endpoints require `initiator_data` with `change_address` (bech32) and `used_addresses` (bech32 array). The CLI only has a `.skey` file.
+
+**Recommended approach: Save address from login, derive as fallback.**
+
+Phase 1 -- Store from login:
+- The headless login response already returns `cardano_bech32_addr` (`cmd/andamio/user.go:313`)
+- Currently not saved to config. **Add `UserAddress string` to `Config` struct.**
+- Save during both browser and headless login flows
+- Use as `change_address` and sole `used_addresses` element
+
+Phase 2 (optional) -- Derive from skey:
+- Compute `blake2b-224(pubKey)` to get key hash (already have `blake2b224` in `internal/cardano/sign.go`)
+- Detect network from `cfg.BaseURL`: `preprod.api.` -> testnet, `mainnet.api.` -> mainnet
+- Encode as bech32 enterprise address: `addr_test1` (testnet header 0x60) or `addr1` (mainnet header 0x61)
+- Requires adding a bech32 library dependency (or minimal implementation)
+
+Phase 1 is sufficient for v1. The address is already returned by the API -- we just need to persist it.
+
+### Two-Phase Commit: On-Chain + Off-Chain
+
+The `SubmitAssignmentCommitmentV2Request` schema confirms a `pending_tx_hash` field. This reveals the pattern:
+
+1. **On-chain**: Evidence hash goes into `assignment_info`/`task_info` as part of the Cardano transaction
+2. **Off-chain**: Full Tiptap evidence document + `pending_tx_hash` are sent to the REST API for database storage
+
+The CLI must make BOTH calls. The state machine tracks the on-chain tx, but it cannot reconstruct the full evidence document from just the hash. The off-chain call should happen **after registration** (the API needs the tx to be registered to link it).
+
+**Timing:** Register first, then submit off-chain evidence with `pending_tx_hash`. The API associates the evidence with the pending transaction. When the state machine confirms the on-chain tx, it updates the DB record that already has the evidence.
+
+### Contributor State ID (Project Commands)
+
+`CommitTaskTxRequest` requires `contributor_state_id` -- a policy ID hash. The existing pattern in `project_task.go` resolves this via `findProjectPolicyID()` which fetches from the manager projects list endpoint.
+
+**Question to verify:** Can a contributor access `contributor_state_id` from the contributor projects list endpoint (`/v2/project/contributor/projects/list`)? If not, can it be fetched from the public project endpoint (`/api/v2/project/user/project/{id}`)?
+
+**Fallback:** Add `--contributor-state-id` flag for manual input if API resolution isn't available to contributors.
+
+### Extracting Shared TX Lifecycle
+
+The `tx run` command's orchestration logic (`tx_run.go:93-370`) should be extracted into a reusable function:
+
+```go
+// cmd/andamio/tx_lifecycle.go (new file)
+
+type TxLifecycleParams struct {
+    Endpoint    string
+    Body        interface{}
+    SkeyPath    string
+    TxType      string
+    InstanceID  string
+    Metadata    map[string]string
+    NoWait      bool
+    Timeout     time.Duration
+    SubmitURL   string
+    Headers     []string
+}
+
+func executeTxLifecycle(cmd *cobra.Command, c *client.Client, params TxLifecycleParams) (*RunResult, error)
+```
+
+Both `tx run` and the new commands call this. `tx run` constructs params from its flags. The new commands construct params programmatically with evidence-derived values.
+
+### Evidence Is Optional
+
+The build schemas show `assignment_info` and `task_info` are not required fields. Users might want to commit first and submit evidence later (matching the two-step off-chain flow).
+
+If `--evidence`/`--evidence-file` is omitted:
+- Skip Tiptap conversion and hashing
+- Omit `assignment_info`/`task_info` from build body
+- Skip off-chain evidence submission
+- Just execute the on-chain commitment tx
+
+This keeps the command useful for commit-only flows.
+
+### Error Handling
+
+Same model as `tx run` with domain-specific additions:
+
+| Stage | Error | Action |
+|-------|-------|--------|
+| Evidence prep | Markdown parse failure | Exit with parse error |
+| SLT/task resolution | Module not on-chain | Exit: "Module X has no slt_hash. Is it published?" |
+| SLT/task resolution | Module/task not found | Exit: "Module code X not found. Run `andamio course modules <id>`" |
+| Build | Insufficient funds | Exit with balance hint |
+| Build | No access token | Exit: "Mint an access token first: `andamio tx run ...`" |
+| Build | Commitment already exists | Exit: "Active commitment exists. Use `update-tx` or `leave` first" |
+| Sign | Key mismatch | Exit: "Signing key does not match authenticated user" |
+| Off-chain submit | API error | Warning (tx is already on-chain). Print tx_hash for manual recovery |
+| Poll | Timeout | Exit with tx_hash for `andamio tx status` follow-up |
+
+The `fail()` closure pattern from `tx run` captures partial progress in `RunResult` for JSON output.
+
+## System-Wide Impact
+
+- **API surface parity**: The app (`assignment-commitment.tsx`) does this flow in the browser. CLI parity means any commitment flow works headlessly.
+- **State lifecycle**: Two-phase commit means partial failure is possible (on-chain succeeds, off-chain fails). The `pending_tx_hash` pattern handles this -- the state machine will still confirm the on-chain tx, and evidence can be re-submitted via the existing `course student submit` command.
+- **Integration test scenarios**: (1) Full commit-tx with evidence end-to-end on preprod, (2) commit-tx without evidence (commit-only), (3) off-chain failure recovery, (4) skey/JWT mismatch detection.
+
+## Acceptance Criteria
+
+### Course Student Commit-TX
+
+- [x] `course student commit-tx` builds on-chain tx with evidence hash as `assignment_info`
+- [x] Evidence markdown is converted to Tiptap JSON and Blake2b-256 hashed automatically
+- [x] `slt_hash` is resolved from `--module-code` automatically
+- [x] Full tx lifecycle: build -> sign -> submit -> register -> poll
+- [x] Off-chain evidence submitted with `pending_tx_hash` after registration
+- [x] `--output json` produces structured result with `tx_hash`, `evidence_hash`, `slt_hash`
+- [x] Evidence is optional -- omitting `--evidence`/`--evidence-file` does commit-only
+- [x] Works without TTY (composable, no interactive prompts)
+- [x] Progress messages to stderr, suppressed in JSON mode
+
+### Project Contributor Commit-TX
+
+- [x] `project contributor commit-tx` mirrors the course flow for task commitments
+- [x] `task_hash` resolved from `--task-index` automatically
+- [x] `contributor_state_id` resolved automatically (from contributor projects list)
+- [x] Tx type `task_submit`, instance_id = project_id
+- [x] Same evidence handling, same lifecycle, same output contract
+
+### Infrastructure
+
+- [x] `UserAddress` saved to config during headless login
+- [x] TX lifecycle extracted into reusable `executeTxLifecycle()` function
+- [x] `tx run` refactored to use `executeTxLifecycle()` (no behavior change)
+- [x] Extended `CommitTxResult` struct with domain-specific fields
+
+## Dependencies & Risks
+
+### Dependencies
+- Headless login must return `cardano_bech32_addr` (it does -- `user.go:313`)
+- Off-chain submit endpoints must accept `pending_tx_hash` (confirmed in OpenAPI: `SubmitAssignmentCommitmentV2Request`)
+- `contributor_state_id` must be resolvable by contributors (needs verification)
+
+### Risks
+- **Two-phase failure**: On-chain tx succeeds but off-chain evidence call fails. Mitigated by `pending_tx_hash` pattern -- evidence can be re-submitted.
+- **Address mismatch**: Config address doesn't match skey. Mitigated by comparing key hash against stored address before building.
+- **Schema drift**: Build endpoint schemas may change. Mitigated by checking OpenAPI spec before implementation.
+
+## Implementation Order
+
+### Phase 1: Infrastructure (1 PR)
+1. Add `UserAddress` to `Config` struct, save from login responses
+2. Extract `executeTxLifecycle()` from `tx run` into `tx_lifecycle.go`
+3. Refactor `tx run` to use `executeTxLifecycle()` -- zero behavior change, all existing tests pass
+
+### Phase 2: Course Student Commit-TX (1 PR)
+1. Add `course student commit-tx` command in `course_student.go`
+2. Wire: readEvidence -> wrapEvidence -> resolveSltHash -> build body -> executeTxLifecycle -> off-chain submit
+3. Test against preprod with the existing bash script as reference
+
+### Phase 3: Project Contributor Commit-TX (1 PR)
+1. Add `project contributor commit-tx` command in `project_contributor.go`
+2. Wire: readEvidence -> wrapEvidence -> resolveTaskHash -> resolve contributor_state_id -> build body -> executeTxLifecycle -> off-chain update
+3. Test against preprod
+
+### Future (out of scope)
+- `course student update-tx` (on-chain evidence update via `/v2/tx/course/student/assignment/update`)
+- `course student claim-tx` (on-chain credential claim)
+- `project contributor action-tx` (on-chain task action)
+- Address derivation from skey (Phase 2 of address resolution)
+- `--dry-run` flag to preview build body without executing
+
+## Questions to Verify Before Implementation
+
+1. **`contributor_state_id` access**: Does `/v2/project/contributor/projects/list` or `/api/v2/project/user/project/{id}` return `contributor_state_id`? If not, add `--contributor-state-id` flag.
+2. **`fee_tier` for project commit**: Is it optional? What are valid values? Try omitting it against preprod.
+3. **Off-chain timing**: Does the off-chain submit work immediately after registration, or does the tx need to be in a specific state first? Test with preprod.
+4. **`alias` in build body**: Is it the `cfg.UserAlias` or can the API infer from JWT? Test by omitting.
+
+## Sources & References
+
+### Issue
+- GitHub Issue #38: `course student create: accept evidence content for assignment commitment tx`
+
+### Brainstorms
+- `docs/brainstorms/2026-03-20-tx-run-full-lifecycle-command-brainstorm.md` -- tx run design decisions
+- `docs/brainstorms/2026-03-18-cli-wallet-signing-brainstorm.md` -- signing architecture, build endpoint inventory
+- `docs/brainstorms/2026-03-20-full-api-coverage-brainstorm.md` -- command naming, role-based nesting
+
+### Institutional Learnings
+- `docs/solutions/integration-issues/evidence-submission-payload-format-and-field-alignment.md` -- wrapEvidence pattern, field name gotchas
+- `docs/solutions/security-issues/tx-signing-code-review-witness-drop-url-validation.md` -- never discard crypto errors
+- `docs/solutions/feature-implementations/cli-course-import-markdown-to-tiptap-conversion.md` -- goldmark pipeline
+
+### OpenAPI Schemas (from `openapi.json`)
+- `CommitAssignmentTxRequest` -- build body for course assignment commit
+- `CommitTaskTxRequest` -- build body for project task commit
+- `SubmitAssignmentCommitmentV2Request` -- off-chain evidence with `pending_tx_hash`
+- `RegisterPendingTxRequest` -- tx_type enum: `assignment_submit`, `task_submit`
+- `WalletData` -- `change_address` + `used_addresses`
+
+### Key Files
+- `cmd/andamio/tx_run.go` -- existing lifecycle to extract
+- `cmd/andamio/helpers.go:230` -- `wrapEvidence()`, `resolveSltHash()`, `resolveTaskHash()`
+- `cmd/andamio/course_student.go` -- existing off-chain student commands
+- `cmd/andamio/project_contributor.go` -- existing off-chain contributor commands
+- `internal/cardano/sign.go` -- signing, Blake2b256
+- `internal/config/config.go` -- Config struct (needs `UserAddress`)
+- `cmd/andamio/user.go:313` -- `cardano_bech32_addr` from login response

--- a/internal/cardano/sign.go
+++ b/internal/cardano/sign.go
@@ -210,6 +210,12 @@ func blake2b224(data []byte) []byte {
 	return h.Sum(nil)
 }
 
+// PubKeyHash computes the Blake2b-224 key hash of a public key, returned as hex.
+// This is the standard Cardano key hash used in addresses and required_signers.
+func PubKeyHash(pubKey ed25519.PublicKey) string {
+	return hex.EncodeToString(blake2b224(pubKey))
+}
+
 // MessageSignResult contains the output of CIP-8 message signing.
 type MessageSignResult struct {
 	Signature string `json:"signature"` // COSE_Sign1 hex

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	JWTExpiresAt string `json:"jwt_expires_at,omitempty"`
 	UserAlias    string `json:"user_alias,omitempty"`
 	UserID       string `json:"user_id,omitempty"`
+	UserAddress  string `json:"user_address,omitempty"`
 	SubmitURL    string `json:"submit_url,omitempty"`
 }
 
@@ -25,6 +26,7 @@ func (c *Config) ClearUserAuth() {
 	c.JWTExpiresAt = ""
 	c.UserAlias = ""
 	c.UserID = ""
+	c.UserAddress = ""
 }
 
 // HasUserAuth returns true if the config has a user JWT stored.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	UserAlias    string `json:"user_alias,omitempty"`
 	UserID       string `json:"user_id,omitempty"`
 	UserAddress  string `json:"user_address,omitempty"`
+	UserKeyHash  string `json:"user_key_hash,omitempty"`
 	SubmitURL    string `json:"submit_url,omitempty"`
 }
 
@@ -27,6 +28,7 @@ func (c *Config) ClearUserAuth() {
 	c.UserAlias = ""
 	c.UserID = ""
 	c.UserAddress = ""
+	c.UserKeyHash = ""
 }
 
 // HasUserAuth returns true if the config has a user JWT stored.


### PR DESCRIPTION
## Summary

- Add `course student commit-tx` — on-chain assignment commitment with evidence in a single command
- Add `project contributor commit-tx` — on-chain task commitment with evidence (parallel implementation)
- Extract `executeTxLifecycle()` from `tx run` into reusable function for both commands
- Save `UserAddress` (bech32) from headless login response to config

Closes #38

## What changed

### Infrastructure
- `internal/config/config.go` — Added `UserAddress` field, cleared on logout
- `cmd/andamio/tx_lifecycle.go` — New file: extracted build→sign→submit→register→poll into `executeTxLifecycle()`
- `cmd/andamio/tx_run.go` — Refactored to use `executeTxLifecycle()` (zero behavior change)
- `cmd/andamio/user.go` — Save `cardano_bech32_addr` from headless login response

### New commands
- `cmd/andamio/course_student.go` — `commit-tx` command + `CommitTxResult` struct + `resolveContributorStateID()` helper
- `cmd/andamio/project_contributor.go` — `commit-tx` command (parallel to course version)

### How they work

Both commands wire together existing building blocks:
1. `readEvidenceFlag()` → raw markdown (optional)
2. `wrapEvidence()` → Tiptap JSON + Blake2b-256 hash
3. `resolveSltHash()` / `resolveTaskHash()` → on-chain identifiers
4. Build body with hash as `assignment_info` / `task_info`
5. `executeTxLifecycle()` → build→sign→submit→register→poll
6. Off-chain evidence submission with `pending_tx_hash`

Evidence is optional — omit `--evidence`/`--evidence-file` for commit-only transactions.

## Testing

- `go build`, `go vet`, `go test ./...` all pass
- Both commands register and show correct `--help` output
- Existing `tx run` tests pass (refactor was behavior-preserving)
- Needs preprod integration testing with actual `.skey` and course/project

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: CLI-only change, no server-side impact. Validation is via preprod integration testing with actual Cardano transactions.

## Questions to verify during testing

1. Does the off-chain submit work immediately after registration, or does the tx need a specific state?
2. Is `alias` required in build body or can API infer from JWT?
3. Is `fee_tier` required for project task commit, or does the API default?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>