### PR TITLE
fix: derive wallet address from skey during headless login (#40)

### DIFF
--- a/cmd/andamio/user.go
+++ b/cmd/andamio/user.go
@@ -337,6 +337,19 @@ func runHeadlessLogin(cfg *config.Config, skeyPath, alias string) error {
 	}
 	cfg.UserKeyHash = signResult.KeyHash
 
+	// Derive enterprise address from skey if API didn't return one
+	if cfg.UserAddress == "" {
+		derived, deriveErr := cardano.DeriveEnterpriseAddress(pubKey, cfg.IsMainnet())
+		if deriveErr == nil {
+			cfg.UserAddress = derived
+			if !isJSON {
+				fmt.Fprintf(os.Stderr, "Derived address from signing key: %s\n", derived)
+			}
+		} else if !isJSON {
+			fmt.Fprintf(os.Stderr, "Warning: could not derive address from signing key: %v\n", deriveErr)
+		}
+	}
+
 	if err := config.Save(cfg); err != nil {
 		return fmt.Errorf("failed to save config: %w", err)
 	}
@@ -352,6 +365,7 @@ func runHeadlessLogin(cfg *config.Config, skeyPath, alias string) error {
 
 	fmt.Fprintf(os.Stderr, "\nAuthenticated as: %s\n", cfg.UserAlias)
 	fmt.Fprintf(os.Stderr, "User ID: %s\n", cfg.UserID)
+	fmt.Fprintf(os.Stderr, "Address: %s\n", cfg.UserAddress)
 	fmt.Fprintf(os.Stderr, "Key hash: %s\n", signResult.KeyHash)
 
 	return nil

--- a/docs/plans/2026-03-23-fix-derive-wallet-address-from-skey-plan.md
+++ b/docs/plans/2026-03-23-fix-derive-wallet-address-from-skey-plan.md
@@ -1,0 +1,136 @@
+---
+title: "fix: Derive wallet address from skey during headless login"
+type: fix
+status: completed
+date: 2026-03-23
+origin: GitHub Issue #40
+---
+
+# Derive Wallet Address from Skey During Headless Login
+
+## Problem
+
+`andamio user login --skey ./payment.skey --alias otter` does not store a wallet address in config when the API returns `null` for `cardano_bech32_addr`. This blocks `course student commit-tx` and `project contributor commit-tx`, which require `cfg.UserAddress` for the `initiator_data` build body field.
+
+Re-logging in doesn't fix it because the address comes from the API, not the key.
+
+## Proposed Solution
+
+During headless login, if the API doesn't return an address, derive the enterprise address locally from the skey's public key. The CLI already has all the primitives:
+
+1. `cardano.LoadSigningKey(path)` returns `(privKey, pubKey, error)`
+2. `blake2b224(pubKey)` computes the 28-byte key hash
+3. `btcsuite/btcd/btcutil/bech32` is already a transitive dependency (via Bursa)
+
+### Cardano Enterprise Address Format
+
+An enterprise address (no staking component) is:
+
+```
+header_byte || blake2b_224(pubKey)
+```
+
+- Testnet (preprod): header = `0x60`, HRP = `addr_test`
+- Mainnet: header = `0x61`, HRP = `addr`
+
+Bech32 encoding of that 29-byte payload with the appropriate HRP gives the address.
+
+### Network Detection
+
+Derive from `cfg.BaseURL`:
+- Contains `preprod` or `testnet` -> testnet
+- Contains `mainnet` -> mainnet
+- Default (localhost, unknown) -> testnet (safe default)
+
+## Implementation
+
+### File: `internal/cardano/address.go` (new)
+
+```go
+func DeriveEnterpriseAddress(pubKey ed25519.PublicKey, isMainnet bool) (string, error) {
+    keyHash := blake2b224(pubKey)
+
+    header := byte(0x60) // testnet enterprise
+    if isMainnet {
+        header = 0x61 // mainnet enterprise
+    }
+
+    payload := append([]byte{header}, keyHash...)
+
+    // Bech32 encode
+    conv, err := bech32.ConvertBits(payload, 8, 5, true)
+    if err != nil {
+        return "", fmt.Errorf("bech32 convert: %w", err)
+    }
+
+    hrp := "addr_test"
+    if isMainnet {
+        hrp = "addr"
+    }
+
+    addr, err := bech32.Encode(hrp, conv)
+    if err != nil {
+        return "", fmt.Errorf("bech32 encode: %w", err)
+    }
+    return addr, nil
+}
+```
+
+### File: `internal/config/config.go`
+
+```go
+func (c *Config) IsMainnet() bool {
+    return strings.Contains(c.BaseURL, "mainnet")
+}
+```
+
+### File: `cmd/andamio/user.go` (modify `runHeadlessLogin`)
+
+After the existing address-from-API block (line 335-337), add fallback derivation:
+
+```go
+if tokenResp.User.CardanoBech32Addr != nil {
+    cfg.UserAddress = *tokenResp.User.CardanoBech32Addr
+}
+// Derive address from skey if API didn't return one
+if cfg.UserAddress == "" {
+    _, pubKey, err := cardano.LoadSigningKey(skeyPath)
+    if err == nil {
+        derived, err := cardano.DeriveEnterpriseAddress(pubKey, cfg.IsMainnet())
+        if err == nil {
+            cfg.UserAddress = derived
+            if !isJSON {
+                fmt.Fprintf(os.Stderr, "Derived address from signing key: %s\n", derived)
+            }
+        }
+    }
+}
+```
+
+Note: `skeyPath` is already in scope from the function parameter. No need to reload the key — but `LoadSigningKey` is cheap and the login flow already loaded it once for `SignMessage`. A minor optimization would be to pass the already-loaded pubKey, but it's not worth the API change.
+
+## Acceptance Criteria
+
+- [x] Headless login derives enterprise address when API returns null
+- [x] Correct testnet address (`addr_test1...`) for preprod
+- [x] Correct mainnet address (`addr1...`) for mainnet
+- [x] Derived address matches the `.addr` file from `cardano-cli` for the same key
+- [x] `commit-tx` commands work after headless login without manual config editing
+- [x] API-returned address still takes precedence when available
+- [x] `--output json` includes the derived address
+- [x] `DeriveEnterpriseAddress` has unit tests (known test vector)
+
+## Context
+
+- `btcsuite/btcd/btcutil/bech32` is available as transitive dependency via Bursa
+- `blake2b224` is already implemented in `internal/cardano/sign.go:206`
+- The key hash is already computed and stored as `cfg.UserKeyHash` during login
+- The `warnSkeyMismatch` helper in `helpers.go` already uses `PubKeyHash` for validation
+
+## Sources
+
+- GitHub Issue #40
+- `internal/cardano/sign.go:206` — `blake2b224()` function
+- `internal/cardano/sign.go:213` — `PubKeyHash()` function
+- `cmd/andamio/user.go:335-337` — current address storage from API
+- CIP-19 address format: header byte + key hash, bech32 encoded

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.5
 require (
 	github.com/adrg/frontmatter v0.2.0
 	github.com/blinklabs-io/bursa v0.16.0
+	github.com/btcsuite/btcd/btcutil v1.1.6
 	github.com/fxamacker/cbor/v2 v2.9.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/spf13/cobra v1.10.2
@@ -21,7 +22,6 @@ require (
 	github.com/blinklabs-io/gouroboros v0.157.0 // indirect
 	github.com/blinklabs-io/plutigo v0.0.23 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.6 // indirect
-	github.com/btcsuite/btcd/btcutil v1.1.6 // indirect
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0 // indirect
 	github.com/consensys/gnark-crypto v0.19.2 // indirect
 	github.com/decred/dcrd/crypto/blake256 v1.1.0 // indirect

--- a/internal/cardano/address.go
+++ b/internal/cardano/address.go
@@ -1,0 +1,42 @@
+package cardano
+
+import (
+	"crypto/ed25519"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcutil/bech32"
+)
+
+// DeriveEnterpriseAddress derives a Cardano enterprise address (no staking component)
+// from an ed25519 public key. Uses blake2b-224 key hash with the appropriate
+// network header byte and bech32 encoding per CIP-19.
+//
+// Testnet: header 0x60, HRP "addr_test"
+// Mainnet: header 0x61, HRP "addr"
+func DeriveEnterpriseAddress(pubKey ed25519.PublicKey, isMainnet bool) (string, error) {
+	keyHash := blake2b224(pubKey)
+
+	header := byte(0x60) // testnet enterprise address
+	hrp := "addr_test"
+	if isMainnet {
+		header = 0x61
+		hrp = "addr"
+	}
+
+	payload := make([]byte, 0, 29) // 1 header + 28 key hash
+	payload = append(payload, header)
+	payload = append(payload, keyHash...)
+
+	// Convert 8-bit groups to 5-bit groups for bech32
+	conv, err := bech32.ConvertBits(payload, 8, 5, true)
+	if err != nil {
+		return "", fmt.Errorf("bech32 bit conversion: %w", err)
+	}
+
+	addr, err := bech32.Encode(hrp, conv)
+	if err != nil {
+		return "", fmt.Errorf("bech32 encode: %w", err)
+	}
+
+	return addr, nil
+}

--- a/internal/cardano/address_test.go
+++ b/internal/cardano/address_test.go
@@ -1,0 +1,87 @@
+package cardano
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+func TestDeriveEnterpriseAddress(t *testing.T) {
+	// Use a deterministic seed to get a known key pair
+	seed := make([]byte, 32)
+	for i := range seed {
+		seed[i] = byte(i)
+	}
+	privKey := ed25519.NewKeyFromSeed(seed)
+	pubKey := privKey.Public().(ed25519.PublicKey)
+
+	// Compute expected key hash for verification
+	keyHash := blake2b224(pubKey)
+	keyHashHex := hex.EncodeToString(keyHash)
+
+	t.Run("testnet address", func(t *testing.T) {
+		addr, err := DeriveEnterpriseAddress(pubKey, false)
+		if err != nil {
+			t.Fatalf("DeriveEnterpriseAddress(testnet) error: %v", err)
+		}
+		if !strings.HasPrefix(addr, "addr_test1") {
+			t.Errorf("testnet address should start with addr_test1, got: %s", addr)
+		}
+		// Pinned test vector for deterministic seed [0,1,2,...,31]
+		wantKeyHash := "27e38d0e19e3434e33fbd001d3fe04b5b76763f88acd625e0d770b43"
+		if keyHashHex != wantKeyHash {
+			t.Errorf("key hash = %s, want %s", keyHashHex, wantKeyHash)
+		}
+		wantAddr := "addr_test1vqn78rgwr835xn3nl0gqr5l7qj6mwemrlz9v6cj7p4mskscud5urh"
+		if addr != wantAddr {
+			t.Errorf("testnet address = %s, want %s", addr, wantAddr)
+		}
+	})
+
+	t.Run("mainnet address", func(t *testing.T) {
+		addr, err := DeriveEnterpriseAddress(pubKey, true)
+		if err != nil {
+			t.Fatalf("DeriveEnterpriseAddress(mainnet) error: %v", err)
+		}
+		if !strings.HasPrefix(addr, "addr1") {
+			t.Errorf("mainnet address should start with addr1, got: %s", addr)
+		}
+		// Mainnet should NOT have _test prefix
+		if strings.HasPrefix(addr, "addr_test") {
+			t.Errorf("mainnet address should not have _test prefix, got: %s", addr)
+		}
+		t.Logf("mainnet address: %s", addr)
+	})
+
+	t.Run("deterministic output", func(t *testing.T) {
+		addr1, _ := DeriveEnterpriseAddress(pubKey, false)
+		addr2, _ := DeriveEnterpriseAddress(pubKey, false)
+		if addr1 != addr2 {
+			t.Errorf("same key should produce same address: %s vs %s", addr1, addr2)
+		}
+	})
+
+	t.Run("different networks produce different addresses", func(t *testing.T) {
+		testnet, _ := DeriveEnterpriseAddress(pubKey, false)
+		mainnet, _ := DeriveEnterpriseAddress(pubKey, true)
+		if testnet == mainnet {
+			t.Errorf("testnet and mainnet addresses should differ")
+		}
+	})
+
+	t.Run("different keys produce different addresses", func(t *testing.T) {
+		seed2 := make([]byte, 32)
+		for i := range seed2 {
+			seed2[i] = byte(i + 100)
+		}
+		privKey2 := ed25519.NewKeyFromSeed(seed2)
+		pubKey2 := privKey2.Public().(ed25519.PublicKey)
+
+		addr1, _ := DeriveEnterpriseAddress(pubKey, false)
+		addr2, _ := DeriveEnterpriseAddress(pubKey2, false)
+		if addr1 == addr2 {
+			t.Errorf("different keys should produce different addresses")
+		}
+	})
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,11 @@ func (c *Config) HasUserAuth() bool {
 	return c.UserJWT != ""
 }
 
+// IsMainnet returns true if the base URL points to mainnet.
+func (c *Config) IsMainnet() bool {
+	return strings.Contains(c.BaseURL, "mainnet")
+}
+
 func DefaultConfig() *Config {
 	return &Config{
 		BaseURL: "https://preprod.api.andamio.io",


### PR DESCRIPTION
## Summary

- Derive enterprise address from skey public key when API doesn't return `cardano_bech32_addr`
- Uses CIP-19 format: header byte + blake2b-224(pubKey), bech32-encoded
- Network auto-detected from config base URL (preprod vs mainnet)

Closes #40

## What changed

- `internal/cardano/address.go` — New `DeriveEnterpriseAddress(pubKey, isMainnet)` function
- `internal/cardano/address_test.go` — Unit tests with pinned test vector
- `internal/config/config.go` — `IsMainnet()` helper
- `cmd/andamio/user.go` — Fallback address derivation in headless login when API returns null

## Testing

- Unit test with deterministic seed and pinned bech32 output
- Tests verify: testnet prefix, mainnet prefix, determinism, network differentiation, key differentiation
- `go build`, `go vet`, `go test ./...` all pass

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: CLI-only change affecting local address derivation during login.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>