### PR TITLE
feat: add compute-hash commands for course modules and tasks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,8 @@ The app URL is derived from the API URL by replacing `.api.` with `.app.` in the
 | `course student update` | `/v2/course/student/commitment/update` | jwt | Update evidence. `--course-id`, `--module-code`, `--evidence` or `--evidence-file` (Markdown) |
 | `course student leave` | `/v2/course/student/commitment/leave` | jwt | Leave commitment. `--course-id`, `--module-code`, `--pending-tx-hash` |
 | `course student claim` | `/v2/course/student/commitment/claim` | jwt | Claim credential. `--course-id`, `--module-code`, `--pending-tx-hash` |
+| `course credential verify-hash <course-id>` | `/api/v2/course/user/modules/{id}` | either | Verify credential hashes match computed SLT hashes |
+| `course credential compute-hash` | local | none | Compute SLT hash from `--slt` flags or `--file` (outline.md). No auth required |
 
 ### project — Project data
 | Command | Endpoint | Auth | Description |
@@ -167,6 +169,7 @@ The app URL is derived from the API URL by replacing `.api.` with `.app.` in the
 | `project task export <project-id>` | `/v2/project/manager/tasks/list` | jwt | Export tasks to tasks/<slug>/ as Markdown |
 | `project task import <project-id>` | `/v2/project/manager/task/create,update` | jwt | Import tasks from Markdown files. --dry-run supported |
 | `project task verify-hash <project-id>` | `/v2/project/user/tasks/list` | either | Verify task hashes match computed hashes (diagnostic) |
+| `project task compute-hash` | local | none | Compute task hash from `--content`, `--lovelace`, `--expiration`, `--token` flags or `--file`. No auth required |
 
 ### tx — Transactions
 | Command | Endpoint | Auth | Description |

--- a/cmd/andamio/course_credential.go
+++ b/cmd/andamio/course_credential.go
@@ -28,6 +28,7 @@ Examples:
   andamio course credential compute-hash --slt "Describe how X works" --slt "Build Y"
   andamio course credential compute-hash --file ./compiled/my-course/101/outline.md
   andamio course credential compute-hash --file outline.md --output json`,
+	Args: cobra.NoArgs,
 	RunE: runCredentialComputeHash,
 }
 

--- a/cmd/andamio/course_credential.go
+++ b/cmd/andamio/course_credential.go
@@ -59,7 +59,7 @@ func init() {
 	courseCredentialCmd.AddCommand(courseCredentialVerifyHashCmd)
 	courseCredentialCmd.AddCommand(courseCredentialComputeHashCmd)
 
-	courseCredentialComputeHashCmd.Flags().StringSlice("slt", nil, "SLT text (repeatable)")
+	courseCredentialComputeHashCmd.Flags().StringArray("slt", nil, "SLT text (repeatable)")
 	courseCredentialComputeHashCmd.Flags().String("file", "", "Path to outline.md file containing SLTs")
 }
 
@@ -183,7 +183,7 @@ func runCredentialVerifyHash(cmd *cobra.Command, args []string) error {
 func runCredentialComputeHash(cmd *cobra.Command, args []string) error {
 	isJSON := output.GetFormat() == output.FormatJSON
 
-	sltFlags, _ := cmd.Flags().GetStringSlice("slt")
+	sltFlags, _ := cmd.Flags().GetStringArray("slt")
 	fileFlag, _ := cmd.Flags().GetString("file")
 
 	if len(sltFlags) > 0 && fileFlag != "" {

--- a/cmd/andamio/course_credential.go
+++ b/cmd/andamio/course_credential.go
@@ -12,6 +12,25 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var courseCredentialComputeHashCmd = &cobra.Command{
+	Use:   "compute-hash",
+	Short: "Compute SLT hash from SLT texts or an outline file",
+	Long: `Compute the Blake2b-256 hash of SLT texts, matching the on-chain Plutus validator.
+
+This is the same hash used for credential verification on-chain. Use it to
+pre-compute the slt_hash before minting a module.
+
+Provide SLTs either as repeated --slt flags or via --file pointing to an outline.md.
+
+No authentication required — this is a purely local computation.
+
+Examples:
+  andamio course credential compute-hash --slt "Describe how X works" --slt "Build Y"
+  andamio course credential compute-hash --file ./compiled/my-course/101/outline.md
+  andamio course credential compute-hash --file outline.md --output json`,
+	RunE: runCredentialComputeHash,
+}
+
 var courseCredentialCmd = &cobra.Command{
 	Use:   "credential",
 	Short: "Credential verification commands",
@@ -38,6 +57,10 @@ Examples:
 func init() {
 	courseCmd.AddCommand(courseCredentialCmd)
 	courseCredentialCmd.AddCommand(courseCredentialVerifyHashCmd)
+	courseCredentialCmd.AddCommand(courseCredentialComputeHashCmd)
+
+	courseCredentialComputeHashCmd.Flags().StringSlice("slt", nil, "SLT text (repeatable)")
+	courseCredentialComputeHashCmd.Flags().String("file", "", "Path to outline.md file containing SLTs")
 }
 
 func runCredentialVerifyHash(cmd *cobra.Command, args []string) error {
@@ -154,5 +177,47 @@ func runCredentialVerifyHash(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "\nAll %d credential hashes verified.\n", len(results))
 	}
 
+	return nil
+}
+
+func runCredentialComputeHash(cmd *cobra.Command, args []string) error {
+	isJSON := output.GetFormat() == output.FormatJSON
+
+	sltFlags, _ := cmd.Flags().GetStringSlice("slt")
+	fileFlag, _ := cmd.Flags().GetString("file")
+
+	if len(sltFlags) > 0 && fileFlag != "" {
+		return fmt.Errorf("cannot use both --slt and --file; choose one input method")
+	}
+
+	var slts []string
+
+	if fileFlag != "" {
+		data, err := os.ReadFile(fileFlag)
+		if err != nil {
+			return fmt.Errorf("failed to read file: %w", err)
+		}
+		slts = parseSLTsFromOutline(string(data))
+		if len(slts) == 0 {
+			return fmt.Errorf("no SLTs found in %s (expected a '## SLTs' section with numbered items)", fileFlag)
+		}
+	} else if len(sltFlags) > 0 {
+		slts = sltFlags
+	} else {
+		return fmt.Errorf("provide SLTs via --slt flags or --file; see 'andamio course credential compute-hash --help'")
+	}
+
+	hash := cardano.ComputeSltHash(slts)
+
+	if isJSON {
+		return output.PrintJSON(map[string]interface{}{
+			"slt_hash":  hash,
+			"slt_count": len(slts),
+			"slts":      slts,
+		})
+	}
+
+	fmt.Printf("%s\n", hash)
+	fmt.Fprintf(os.Stderr, "SLT count: %d\n", len(slts))
 	return nil
 }

--- a/cmd/andamio/course_credential_test.go
+++ b/cmd/andamio/course_credential_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Andamio-Platform/andamio-cli/internal/cardano"
+)
+
+func TestRunCredentialComputeHash_FromFlags(t *testing.T) {
+	slts := []string{
+		"I can set up a Typescript development environment.",
+		"I can use Github CLI to create an issue.",
+		"I can run the Andamio T3 App Template locally.",
+	}
+	expected := "eff7d90a6ed2eaf32b523efb25d95f748166158bcce048717a4920478be052cf"
+
+	hash := cardano.ComputeSltHash(slts)
+	if hash != expected {
+		t.Errorf("hash mismatch: got %s, want %s", hash, expected)
+	}
+}
+
+func TestRunCredentialComputeHash_FromOutlineFile(t *testing.T) {
+	content := `---
+title: "Test Module"
+code: "101"
+---
+
+# Test Module
+
+## SLTs
+
+1. I can set up a Typescript development environment.
+2. I can use Github CLI to create an issue.
+3. I can run the Andamio T3 App Template locally.
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "outline.md")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	slts := parseSLTsFromOutline(content)
+	if len(slts) != 3 {
+		t.Fatalf("expected 3 SLTs, got %d", len(slts))
+	}
+
+	hash := cardano.ComputeSltHash(slts)
+	expected := "eff7d90a6ed2eaf32b523efb25d95f748166158bcce048717a4920478be052cf"
+	if hash != expected {
+		t.Errorf("hash mismatch: got %s, want %s", hash, expected)
+	}
+}
+
+func TestRunCredentialComputeHash_NoSLTsInFile(t *testing.T) {
+	content := `---
+title: "Empty Module"
+code: "102"
+---
+
+# Empty Module
+
+No SLTs section here.
+`
+	slts := parseSLTsFromOutline(content)
+	if len(slts) != 0 {
+		t.Errorf("expected 0 SLTs, got %d", len(slts))
+	}
+}
+
+func TestRunCredentialComputeHash_Deterministic(t *testing.T) {
+	slts := []string{"Alpha", "Beta"}
+	hash1 := cardano.ComputeSltHash(slts)
+	hash2 := cardano.ComputeSltHash(slts)
+	if hash1 != hash2 {
+		t.Errorf("hash not deterministic: %s != %s", hash1, hash2)
+	}
+}

--- a/cmd/andamio/project_task.go
+++ b/cmd/andamio/project_task.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/hex"
 	"fmt"
 	"os"
@@ -12,6 +13,7 @@ import (
 	"github.com/Andamio-Platform/andamio-cli/internal/client"
 	"github.com/Andamio-Platform/andamio-cli/internal/config"
 	"github.com/Andamio-Platform/andamio-cli/internal/output"
+	"github.com/adrg/frontmatter"
 	"github.com/spf13/cobra"
 )
 
@@ -87,6 +89,31 @@ Requires user authentication via 'andamio user login'.`,
 	RunE: runTaskDelete,
 }
 
+var projectTaskComputeHashCmd = &cobra.Command{
+	Use:   "compute-hash",
+	Short: "Compute task hash from task data fields",
+	Long: `Compute the Blake2b-256 hash of task data, matching the on-chain Plutus validator.
+
+This is the same hash used for task verification on-chain. Use it to
+pre-compute the task_hash before minting a task.
+
+Provide task data either as individual flags or via --file pointing to a
+task markdown file with frontmatter (same format as 'project task export').
+
+No authentication required — this is a purely local computation.
+
+Examples:
+  andamio project task compute-hash --content "Build API" --lovelace 5000000 --expiration 2026-12-31
+  andamio project task compute-hash --content "Earn XP" --lovelace 5000000 --expiration 2026-12-31 --token "policyid...,XP,50"
+  andamio project task compute-hash --file tasks/my-project/001-build-api.md --output json`,
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		// Override parent's jwtAuthPreRunE — this command is purely local,
+		// no auth needed. Only run the root output format setup.
+		return rootCmd.PersistentPreRunE(cmd, args)
+	},
+	RunE: runTaskComputeHash,
+}
+
 var projectTaskVerifyHashCmd = &cobra.Command{
 	Use:   "verify-hash <project-id>",
 	Short: "Verify task hashes match computed hashes",
@@ -113,6 +140,14 @@ func init() {
 	projectTaskCmd.AddCommand(projectTaskUpdateCmd)
 	projectTaskCmd.AddCommand(projectTaskDeleteCmd)
 	projectTaskCmd.AddCommand(projectTaskVerifyHashCmd)
+	projectTaskCmd.AddCommand(projectTaskComputeHashCmd)
+
+	// Compute-hash flags
+	projectTaskComputeHashCmd.Flags().String("content", "", "Task content text (max 140 chars)")
+	projectTaskComputeHashCmd.Flags().String("lovelace", "", "Lovelace reward amount, e.g. 5000000")
+	projectTaskComputeHashCmd.Flags().String("expiration", "", "Expiration time in ISO 8601 format, e.g. 2026-12-31")
+	projectTaskComputeHashCmd.Flags().StringArray("token", nil, `Native asset token (repeatable, format: "policy_id,asset_name,quantity")`)
+	projectTaskComputeHashCmd.Flags().String("file", "", "Path to task markdown file with frontmatter")
 
 	// Create flags
 	projectTaskCreateCmd.Flags().String("title", "", "Task title (required)")
@@ -802,6 +837,139 @@ func runTaskVerifyHash(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Fprintf(os.Stderr, "\n%d tasks checked, %d mismatches\n", len(results), mismatches)
+	return nil
+}
+
+func runTaskComputeHash(cmd *cobra.Command, args []string) error {
+	isJSON := output.GetFormat() == output.FormatJSON
+
+	fileFlag, _ := cmd.Flags().GetString("file")
+	contentFlag, _ := cmd.Flags().GetString("content")
+	lovelaceFlag, _ := cmd.Flags().GetString("lovelace")
+	expirationFlag, _ := cmd.Flags().GetString("expiration")
+	tokenStrs, _ := cmd.Flags().GetStringArray("token")
+
+	hasFieldFlags := contentFlag != "" || lovelaceFlag != "" || expirationFlag != "" || len(tokenStrs) > 0
+
+	if fileFlag != "" && hasFieldFlags {
+		return fmt.Errorf("cannot use --file with --content, --lovelace, --expiration, or --token; choose one input method")
+	}
+
+	var content, lovelace, expiration string
+	var nativeAssets []cardano.NativeAsset
+
+	if fileFlag != "" {
+		data, err := os.ReadFile(fileFlag)
+		if err != nil {
+			return fmt.Errorf("failed to read file: %w", err)
+		}
+
+		var fm TaskFrontmatter
+		_, err = frontmatter.Parse(bytes.NewReader(data), &fm)
+		if err != nil {
+			return fmt.Errorf("failed to parse frontmatter: %w", err)
+		}
+
+		if fm.Title == "" {
+			return fmt.Errorf("file %s is missing required 'title' in frontmatter (used as content)", fileFlag)
+		}
+		content = fm.Title
+
+		if fm.Lovelace == "" {
+			return fmt.Errorf("file %s is missing required 'lovelace' in frontmatter", fileFlag)
+		}
+		lovelace = fm.Lovelace
+
+		if fm.ExpirationTime == "" {
+			return fmt.Errorf("file %s is missing required 'expiration_time' in frontmatter", fileFlag)
+		}
+		expiration = fm.ExpirationTime
+
+		for _, t := range fm.Tokens {
+			assetNameHex := hexEncodeAssetName(t.AssetName)
+			qty, err := strconv.ParseUint(t.Quantity, 10, 64)
+			if err != nil {
+				return fmt.Errorf("invalid token quantity %q: %w", t.Quantity, err)
+			}
+			nativeAssets = append(nativeAssets, cardano.NativeAsset{
+				PolicyID:  t.PolicyID,
+				TokenName: assetNameHex,
+				Quantity:  qty,
+			})
+		}
+	} else {
+		if contentFlag == "" || lovelaceFlag == "" || expirationFlag == "" {
+			return fmt.Errorf("--content, --lovelace, and --expiration are all required (or use --file); see 'andamio project task compute-hash --help'")
+		}
+		content = contentFlag
+		lovelace = lovelaceFlag
+		expiration = expirationFlag
+
+		if len(tokenStrs) > 0 {
+			tokens, err := parseTokenFlags(tokenStrs)
+			if err != nil {
+				return err
+			}
+			for _, t := range tokens {
+				qty, err := strconv.ParseUint(t.Quantity, 10, 64)
+				if err != nil {
+					return fmt.Errorf("invalid token quantity %q: %w", t.Quantity, err)
+				}
+				nativeAssets = append(nativeAssets, cardano.NativeAsset{
+					PolicyID:  t.PolicyID,
+					TokenName: t.AssetName,
+					Quantity:  qty,
+				})
+			}
+		}
+	}
+
+	if err := validateLovelace(lovelace); err != nil {
+		return err
+	}
+
+	expirationMs, err := parseExpiration(expiration)
+	if err != nil {
+		return err
+	}
+	expMs, _ := strconv.ParseUint(expirationMs, 10, 64)
+	lovelaceVal, _ := strconv.ParseUint(lovelace, 10, 64)
+
+	taskData := cardano.TaskData{
+		ProjectContent: content,
+		ExpirationTime: expMs,
+		LovelaceAmount: lovelaceVal,
+		NativeAssets:   nativeAssets,
+	}
+
+	hash, err := cardano.ComputeTaskHash(taskData)
+	if err != nil {
+		return fmt.Errorf("hash computation failed: %w", err)
+	}
+
+	if isJSON {
+		tokensOut := make([]map[string]interface{}, 0, len(nativeAssets))
+		for _, a := range nativeAssets {
+			tokensOut = append(tokensOut, map[string]interface{}{
+				"policy_id":  a.PolicyID,
+				"token_name": a.TokenName,
+				"quantity":   a.Quantity,
+			})
+		}
+		return output.PrintJSON(map[string]interface{}{
+			"task_hash": hash,
+			"fields": map[string]interface{}{
+				"content":       content,
+				"lovelace":      lovelaceVal,
+				"expiration_ms": expMs,
+				"tokens":        tokensOut,
+			},
+		})
+	}
+
+	fmt.Printf("%s\n", hash)
+	fmt.Fprintf(os.Stderr, "Content: %s\n", content)
+	fmt.Fprintf(os.Stderr, "Lovelace: %d, Expiration: %d ms, Tokens: %d\n", lovelaceVal, expMs, len(nativeAssets))
 	return nil
 }
 

--- a/cmd/andamio/project_task.go
+++ b/cmd/andamio/project_task.go
@@ -106,6 +106,7 @@ Examples:
   andamio project task compute-hash --content "Build API" --lovelace 5000000 --expiration 2026-12-31
   andamio project task compute-hash --content "Earn XP" --lovelace 5000000 --expiration 2026-12-31 --token "policyid...,XP,50"
   andamio project task compute-hash --file tasks/my-project/001-build-api.md --output json`,
+	Args: cobra.NoArgs,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		// Override parent's jwtAuthPreRunE — this command is purely local,
 		// no auth needed. Only run the root output format setup.

--- a/cmd/andamio/project_task_test.go
+++ b/cmd/andamio/project_task_test.go
@@ -1,8 +1,13 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/Andamio-Platform/andamio-cli/internal/cardano"
+	"github.com/adrg/frontmatter"
 )
 
 // Valid 56-char hex policy IDs for tests
@@ -184,5 +189,123 @@ func TestHexRoundTrip(t *testing.T) {
 		if decoded != name {
 			t.Errorf("round-trip failed for %q: encoded=%q decoded=%q", name, encoded, decoded)
 		}
+	}
+}
+
+func TestComputeTaskHash_FromFlags_Deterministic(t *testing.T) {
+	task := cardano.TaskData{
+		ProjectContent: "Build API integration",
+		ExpirationTime: 1798761600000, // 2026-12-31T00:00:00Z
+		LovelaceAmount: 5000000,
+	}
+	hash1, err := cardano.ComputeTaskHash(task)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	hash2, err := cardano.ComputeTaskHash(task)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hash1 != hash2 {
+		t.Errorf("hash not deterministic: %s != %s", hash1, hash2)
+	}
+	if len(hash1) != 64 {
+		t.Errorf("expected 64-char hex hash, got %d chars", len(hash1))
+	}
+}
+
+func TestComputeTaskHash_FromFrontmatter(t *testing.T) {
+	content := `---
+title: "Build API integration"
+lovelace: "5000000"
+expiration_time: "2026-12-31T00:00:00Z"
+---
+
+Task body content here.
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "task.md")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify the frontmatter parses correctly
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var fm TaskFrontmatter
+	_, err = frontmatter.Parse(strings.NewReader(string(data)), &fm)
+	if err != nil {
+		t.Fatalf("frontmatter parse error: %v", err)
+	}
+
+	if fm.Title != "Build API integration" {
+		t.Errorf("title = %q, want %q", fm.Title, "Build API integration")
+	}
+	if fm.Lovelace != "5000000" {
+		t.Errorf("lovelace = %q, want %q", fm.Lovelace, "5000000")
+	}
+	if fm.ExpirationTime != "2026-12-31T00:00:00Z" {
+		t.Errorf("expiration = %q, want %q", fm.ExpirationTime, "2026-12-31T00:00:00Z")
+	}
+}
+
+func TestComputeTaskHash_WithTokens(t *testing.T) {
+	task := cardano.TaskData{
+		ProjectContent: "Earn XP",
+		ExpirationTime: 1798761600000,
+		LovelaceAmount: 5000000,
+		NativeAssets: []cardano.NativeAsset{
+			{
+				PolicyID:  testPolicyA,
+				TokenName: "5850", // "XP" hex-encoded
+				Quantity:  50,
+			},
+		},
+	}
+
+	hash, err := cardano.ComputeTaskHash(task)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Same inputs without tokens should produce different hash
+	taskNoTokens := task
+	taskNoTokens.NativeAssets = nil
+	hashNoTokens, _ := cardano.ComputeTaskHash(taskNoTokens)
+
+	if hash == hashNoTokens {
+		t.Error("hash with tokens should differ from hash without tokens")
+	}
+}
+
+func TestParseExpiration_Formats(t *testing.T) {
+	tests := []struct {
+		input   string
+		wantErr bool
+	}{
+		{"2026-12-31T00:00:00Z", false},
+		{"2026-12-31", false},
+		{"not-a-date", true},
+		{"2026/12/31", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result, err := parseExpiration(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error for %q, got result %q", tt.input, result)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error for %q: %v", tt.input, err)
+				}
+				if result == "" {
+					t.Error("expected non-empty result")
+				}
+			}
+		})
 	}
 }

--- a/cmd/andamio/project_task_test.go
+++ b/cmd/andamio/project_task_test.go
@@ -284,12 +284,13 @@ func TestComputeTaskHash_WithTokens(t *testing.T) {
 func TestParseExpiration_Formats(t *testing.T) {
 	tests := []struct {
 		input   string
+		wantMs  string // expected Unix milliseconds string, empty if wantErr
 		wantErr bool
 	}{
-		{"2026-12-31T00:00:00Z", false},
-		{"2026-12-31", false},
-		{"not-a-date", true},
-		{"2026/12/31", true},
+		{"2026-12-31T00:00:00Z", "1798675200000", false},
+		{"2026-12-31", "1798675200000", false}, // date-only = midnight UTC
+		{"not-a-date", "", true},
+		{"2026/12/31", "", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
@@ -302,8 +303,8 @@ func TestParseExpiration_Formats(t *testing.T) {
 				if err != nil {
 					t.Errorf("unexpected error for %q: %v", tt.input, err)
 				}
-				if result == "" {
-					t.Error("expected non-empty result")
+				if result != tt.wantMs {
+					t.Errorf("parseExpiration(%q) = %q, want %q", tt.input, result, tt.wantMs)
 				}
 			}
 		})

--- a/docs/plans/2026-04-02-001-feat-compute-hash-commands-plan.md
+++ b/docs/plans/2026-04-02-001-feat-compute-hash-commands-plan.md
@@ -1,0 +1,179 @@
+---
+title: "feat: add compute-hash commands for course modules and tasks"
+type: feat
+status: completed
+date: 2026-04-02
+---
+
+# feat: add compute-hash commands for course modules and tasks
+
+## Overview
+
+Add `andamio course credential compute-hash` and `andamio project task compute-hash` commands that expose existing internal hash functions as standalone CLI commands. This enables computing hashes from raw inputs before data is on-chain, unblocking the correct course/project setup flow.
+
+## Problem Frame
+
+The CLI has internal hash computation functions (`ComputeSltHash`, `ComputeTaskHash`) but only exposes them through `verify-hash` commands that compare against existing on-chain data. There is no way to compute a hash from raw inputs before the data is on-chain.
+
+This creates a chicken-and-egg problem: the DB API requires an `slt_hash` when approving a module, but the only way to get that hash today is to mint the module on-chain first — leading to DB sync failures during the module creation flow.
+
+## Requirements Trace
+
+- R1. `andamio course credential compute-hash` computes SLT hash from `--slt` flags or `--file` (outline.md)
+- R2. `andamio project task compute-hash` computes task hash from `--content`, `--lovelace`, `--expiration`, and optional `--token` flags
+- R3. Both commands work offline — no API key, JWT, or network required
+- R4. Both commands support `--output json` for scripting
+- R5. JSON output uses stable schemas: `{"slt_hash": "...", "slt_count": N}` and `{"task_hash": "...", "fields": {...}}`
+- R6. Task compute-hash supports `--file` flag to read task data from a markdown file with frontmatter (same format as task export)
+
+## Scope Boundaries
+
+- No commitment hash command in this iteration (issue mentions "if applicable" — defer until needed)
+- No changes to existing `verify-hash` commands
+- No changes to hash computation logic in `internal/cardano/`
+- No integration with `course import` flow (future work)
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `internal/cardano/slt_hash.go` — `ComputeSltHash(slts []string) string`, no error return
+- `internal/cardano/task_hash.go` — `ComputeTaskHash(task TaskData) (string, error)`, validates inputs
+- `cmd/andamio/course_credential.go` — `courseCredentialCmd` parent (no auth gate), `courseCredentialVerifyHashCmd` as pattern
+- `cmd/andamio/project_task.go` — `projectTaskCmd` parent has `PersistentPreRunE: jwtAuthPreRunE`, `projectTaskVerifyHashCmd` as pattern
+- `cmd/andamio/course_import.go:608` — `parseSLTsFromOutline()` extracts SLTs from outline.md
+- `cmd/andamio/project_task.go:310` — `parseExpiration()` parses ISO 8601 dates to Unix ms
+- `cmd/andamio/project_task.go:337` — `parseTokenFlags()` parses `--token` flag values
+- `cmd/andamio/project_task_import.go:42` — `TaskFrontmatter` struct with all needed fields
+
+### Institutional Learnings
+
+- Manual CBOR encoding is required (not fxamacker/cbor) for exact indefinite/definite array control matching on-chain validators (`docs/solutions/architecture/cli-tx-state-machine-pattern-and-task-hash-verification.md`)
+- All progress messages to stderr, data to stdout only (`docs/solutions/architecture/cli-composability-audit-and-fix.md`)
+- No stdin reading in command handlers (`docs/solutions/architecture/non-interactive-cli-stdin-picker-removal.md`)
+- Use `cobra.ExactArgs(N)` for required positional args (`docs/solutions/architecture/command-structure-refactoring.md`)
+
+## Key Technical Decisions
+
+- **Auth bypass for project task compute-hash**: `projectTaskCmd` has `PersistentPreRunE: jwtAuthPreRunE` which enforces JWT auth for all subcommands. Since compute-hash is purely local computation, override `PersistentPreRunE` on the compute-hash command itself to only run `rootCmd`'s `PersistentPreRunE` (which sets output format). This is the simplest approach — avoids restructuring the command tree.
+
+- **No positional args**: Both commands take all input via flags. This avoids the awkwardness of passing multiple SLT strings as positional args and aligns with the issue's proposed interface.
+
+- **`--file` support for both commands**: SLT hash can read from outline.md (reusing `parseSLTsFromOutline`). Task hash can read from a task markdown file with frontmatter (reusing `TaskFrontmatter` parsing from task import). File flags and individual field flags are mutually exclusive.
+
+- **Echo back input fields in JSON output**: Both commands include the parsed input in JSON output so users can verify what was hashed. SLT: `{"slt_hash": "...", "slt_count": 2, "slts": [...]}`. Task: `{"task_hash": "...", "fields": {"content": "...", "lovelace": ..., "expiration": ..., "tokens": [...]}}`.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Where to place commands?**: In existing files — `course_credential.go` and `project_task.go` — alongside the verify-hash commands they complement.
+- **How to handle auth on project task?**: Override `PersistentPreRunE` on the specific command to skip JWT check (confirmed this is a standard Cobra pattern).
+
+### Deferred to Implementation
+
+- **Should `--debug` flag expose raw CBOR bytes?**: `DebugTaskBytes()` exists for tasks. Could add a `--debug` flag to show pre-hash bytes. Decide during implementation based on command complexity.
+
+## Implementation Units
+
+- [x] **Unit 1: `course credential compute-hash` command**
+
+  **Goal:** Add a command that computes SLT hash from flag inputs or an outline.md file.
+
+  **Requirements:** R1, R3, R4, R5
+
+  **Dependencies:** None
+
+  **Files:**
+  - Modify: `cmd/andamio/course_credential.go`
+  - Test: `cmd/andamio/course_credential_test.go`
+
+  **Approach:**
+  - Add `courseCredentialComputeHashCmd` as a subcommand of `courseCredentialCmd`
+  - Two input modes: `--slt` (repeatable string slice flag) or `--file` (path to outline.md)
+  - Validate mutual exclusivity: error if both `--slt` and `--file` provided, or if neither provided
+  - When `--file` is used, read the file and call `parseSLTsFromOutline()` to extract SLTs
+  - Call `cardano.ComputeSltHash(slts)` to compute the hash
+  - Text output: print hash and SLT count to stdout
+  - JSON output: `{"slt_hash": "...", "slt_count": N, "slts": [...]}`
+  - No auth required — `courseCredentialCmd` has no auth gate
+
+  **Patterns to follow:**
+  - `courseCredentialVerifyHashCmd` in `course_credential.go` for command structure
+  - `parseSLTsFromOutline()` in `course_import.go` for file parsing
+  - `isJSON := output.GetFormat() == output.FormatJSON` pattern for output gating
+
+  **Test scenarios:**
+  - Compute hash from `--slt` flags, verify deterministic output
+  - Compute hash from `--file` pointing to a valid outline.md
+  - Error when both `--slt` and `--file` provided
+  - Error when neither `--slt` nor `--file` provided
+  - JSON output includes all expected fields with correct types
+  - File with no SLTs section returns error
+
+  **Verification:**
+  - `andamio course credential compute-hash --slt "text1" --slt "text2"` returns consistent hash
+  - `andamio course credential compute-hash --file outline.md --output json | jq .slt_hash` works in a pipe
+  - Command works with zero config (no `~/.andamio/config.json` needed)
+
+- [x] **Unit 2: `project task compute-hash` command**
+
+  **Goal:** Add a command that computes task hash from flag inputs or a task markdown file.
+
+  **Requirements:** R2, R3, R4, R5, R6
+
+  **Dependencies:** None (can be implemented in parallel with Unit 1)
+
+  **Files:**
+  - Modify: `cmd/andamio/project_task.go`
+  - Test: `cmd/andamio/project_task_test.go`
+
+  **Approach:**
+  - Add `projectTaskComputeHashCmd` as a subcommand of `projectTaskCmd`
+  - Override `PersistentPreRunE` on this command to skip JWT auth: set it to a function that only calls `output.SetFormat()` from the `--output` flag value
+  - Two input modes: individual flags (`--content`, `--lovelace`, `--expiration`, optional `--token`) or `--file` (path to task markdown with frontmatter)
+  - When `--file` is used, parse frontmatter using `adrg/frontmatter` into `TaskFrontmatter`, extract content, lovelace, expiration, and tokens
+  - Convert inputs to `cardano.TaskData` struct: parse expiration via `parseExpiration()` to get Unix ms, parse lovelace to uint64, parse tokens via `parseTokenFlags()` or from frontmatter
+  - Call `cardano.ComputeTaskHash(taskData)` to compute the hash
+  - Text output: print hash and input summary to stdout
+  - JSON output: `{"task_hash": "...", "fields": {"content": "...", "lovelace": N, "expiration_ms": N, "tokens": [...]}}`
+  - No auth required — auth bypass via PersistentPreRunE override
+
+  **Patterns to follow:**
+  - `projectTaskVerifyHashCmd` in `project_task.go` for command structure
+  - `parseExpiration()`, `parseTokenFlags()`, `validateLovelace()` in `project_task.go` for input parsing
+  - `TaskFrontmatter` in `project_task_import.go` for file-based input
+
+  **Test scenarios:**
+  - Compute hash from individual flags, verify deterministic output
+  - Compute hash from `--file` pointing to a task markdown file
+  - Error when both `--file` and individual flags provided
+  - Error when required flags missing (no `--file` and missing `--content`, `--lovelace`, or `--expiration`)
+  - Error on invalid inputs (bad expiration format, negative lovelace, invalid token policy ID)
+  - JSON output includes all expected fields with correct types
+  - Command works without JWT auth (no config needed)
+  - Hash matches known test vectors from `internal/cardano/task_hash_test.go`
+
+  **Verification:**
+  - `andamio project task compute-hash --content "Build API" --lovelace 5000000 --expiration 2026-12-31` returns consistent hash
+  - `andamio project task compute-hash --file task.md --output json | jq .task_hash` works in a pipe
+  - Command works with zero config — no JWT prompt, no API key check
+
+## System-Wide Impact
+
+- **Interaction graph:** No callbacks, middleware, or observers affected. These are pure-computation leaf commands.
+- **Error propagation:** Errors from `cardano.ComputeTaskHash()` (validation failures) propagate directly to user via Cobra's `RunE` error handling.
+- **API surface parity:** These commands complement existing `verify-hash` commands. No other interface needs the same change.
+- **CLI help tree:** Two new commands appear under `andamio course credential` and `andamio project task`. Help text should reference the companion `verify-hash` command.
+
+## Risks & Dependencies
+
+- **Low risk: PersistentPreRunE override**: Overriding `PersistentPreRunE` on a specific subcommand is standard Cobra. The override must still call the root command's output format setup. Verify with `--output json` flag to confirm it still works.
+- **Low risk: parseSLTsFromOutline reuse**: Function is in `course_import.go` but accessible within the same package. No extraction needed.
+
+## Sources & References
+
+- Related issue: Andamio-Platform/andamio-cli#51
+- Existing hash functions: `internal/cardano/slt_hash.go`, `internal/cardano/task_hash.go`
+- Hash verification pattern: `docs/solutions/architecture/cli-tx-state-machine-pattern-and-task-hash-verification.md`
+- Composability rules: `docs/solutions/architecture/cli-composability-audit-and-fix.md`


### PR DESCRIPTION
## Summary

Closes #51

- Add `andamio course credential compute-hash` — computes SLT hash from `--slt` flags or `--file` (outline.md)
- Add `andamio project task compute-hash` — computes task hash from `--content`/`--lovelace`/`--expiration`/`--token` flags or `--file` (task markdown with frontmatter)
- Both commands work offline with zero config (no API key, JWT, or network required)
- Both support `--output json` with stable schemas for scripting

### Why

The CLI had internal hash functions (`ComputeSltHash`, `ComputeTaskHash`) but only exposed them through `verify-hash` commands that compare against on-chain data. There was no way to compute a hash before minting — creating a chicken-and-egg problem where the DB API requires `slt_hash` during module approval but the hash only existed after on-chain minting.

### Key decisions

- **Auth bypass for task command**: `projectTaskCmd` enforces JWT auth on all subcommands. `compute-hash` overrides `PersistentPreRunE` to skip auth since it's purely local computation.
- **`StringArray` not `StringSlice`** for `--slt` flag: `StringSlice` splits on commas, which would silently corrupt hashes when SLT texts contain commas.
- **`cobra.NoArgs`** on both commands to reject accidental positional args (e.g., `compute-hash outline.md` instead of `--file outline.md`).

## Test plan

- [x] `go test ./...` passes
- [x] `andamio course credential compute-hash --slt "text1" --slt "text2"` returns deterministic hash
- [x] `andamio course credential compute-hash --file outline.md` matches known test vector (`eff7d90a...`)
- [x] `andamio project task compute-hash --content "Build API" --lovelace 5000000 --expiration 2026-12-31` works
- [x] `--file` and `--slt`/`--content` flags are mutually exclusive (error on both)
- [x] `--output json` produces stable schemas with echoed input fields
- [x] Commands work with zero config (no `~/.andamio/config.json`)
- [x] SLT text with commas hashes correctly as a single SLT (StringArray fix)
- [x] Positional args rejected with clear error (NoArgs)

🤖 Generated with [Claude Opus 4.6](https://claude.com/claude-code) (1M context) via [Claude Code](https://claude.com/claude-code)