### PR TITLE
docs: document chain/DB sync model and course/project lifecycle workflows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,10 +255,17 @@ andamio project task create "$PROJECT_ID" --title "..." --lovelace 5000000 --exp
 2. Add command using `getJSON("/api/v2/...")` pattern for simple GETs, or the full config→client→output pattern for lists or POST/PUT
 3. Register in `init()`
 
+## Workflow Guides
+
+| Guide | Location | Covers |
+|-------|----------|--------|
+| TX Lifecycle | `docs/TX-LIFECYCLE.md` | 5-step pipeline, terminal states, recovery procedures, all 17 TX types |
+| Course Lifecycle | `docs/COURSE-LIFECYCLE.md` | Course creation, module import, SLT hashes, publishing, student enrollment |
+| Project Lifecycle | `docs/PROJECT-LIFECYCLE.md` | Project creation, task management, contributor workflow, assessments |
+
 ## Planned Features
 
 - **Content Sync** (`sync pull`/`sync push`/`sync status`) — Bidirectional course content sync with conflict detection. Design in `docs/PLAN-content-sync.md`.
-- **Import/Export** — Export module content to local files, edit, reimport. Documented in andamio-docs CLI section.
 
 ## Cross-Repo Context
 

--- a/cmd/andamio/course_import.go
+++ b/cmd/andamio/course_import.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Andamio-Platform/andamio-cli/internal/cardano"
 	"github.com/Andamio-Platform/andamio-cli/internal/apierr"
 	"github.com/Andamio-Platform/andamio-cli/internal/client"
 	"github.com/Andamio-Platform/andamio-cli/internal/config"
@@ -118,6 +119,7 @@ type ImportResult struct {
 	ModuleStatus   string                 `json:"module_status"`
 	SLTsLocked     bool                   `json:"slts_locked"`
 	SLTCount       int                    `json:"slt_count"`
+	SltHash        string                 `json:"slt_hash,omitempty"`
 	LessonCount    int                    `json:"lesson_count"`
 	HasIntro       bool                   `json:"has_introduction"`
 	HasAssignment  bool                   `json:"has_assignment"`
@@ -205,12 +207,17 @@ func importModule(p ImportParams) (*ImportResult, error) {
 				if !p.Quiet {
 					fmt.Printf("Dry-run: would create module %s (%s) with sort_order %d\n", data.Title, data.ModuleCode, p.SortOrder)
 				}
+				var earlyHash string
+				if len(data.SLTs) > 0 {
+					earlyHash = cardano.ComputeSltHash(data.SLTs)
+				}
 				return &ImportResult{
 					CourseID:   p.CourseID,
 					ModuleCode: data.ModuleCode,
 					Title:      data.Title,
 					DryRun:     true,
 					SLTCount:   len(data.SLTs),
+					SltHash:    earlyHash,
 					LessonCount: len(data.Lessons),
 					HasIntro:   data.Introduction != nil,
 					HasAssignment: data.Assignment != nil,
@@ -247,6 +254,11 @@ func importModule(p ImportParams) (*ImportResult, error) {
 		fmt.Printf("Module status is %s — SLTs are locked, updating content only\n", existing.Status)
 	}
 
+	var sltHash string
+	if len(data.SLTs) > 0 {
+		sltHash = cardano.ComputeSltHash(data.SLTs)
+	}
+
 	// Update the module via API (or dump payload in dry-run mode)
 	resp, err := updateModuleContent(p.Client, p.CourseID, data, existing, sltsLocked, p.DryRun)
 	if err != nil {
@@ -266,6 +278,7 @@ func importModule(p ImportParams) (*ImportResult, error) {
 		ModuleStatus:   existing.Status,
 		SLTsLocked:     sltsLocked,
 		SLTCount:       len(data.SLTs),
+		SltHash:        sltHash,
 		LessonCount:    len(data.Lessons),
 		HasIntro:       data.Introduction != nil,
 		HasAssignment:  data.Assignment != nil,
@@ -1206,6 +1219,17 @@ func updateModuleContent(c *client.Client, courseID string, data *ImportData, ex
 			slts[i] = slt
 		}
 		payload["slts"] = slts
+	}
+
+	// Compute and include SLT hash when SLTs exist
+	if len(data.SLTs) > 0 {
+		sltHash := cardano.ComputeSltHash(data.SLTs)
+		if !isJSON {
+			fmt.Fprintf(os.Stderr, "  Computed SLT hash: %s\n", sltHash)
+		}
+		if !sltsLocked {
+			payload["slt_hash"] = sltHash
+		}
 	}
 
 	// Build introduction — H1 title from file, preserve existing metadata

--- a/cmd/andamio/course_import.go
+++ b/cmd/andamio/course_import.go
@@ -17,8 +17,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Andamio-Platform/andamio-cli/internal/cardano"
 	"github.com/Andamio-Platform/andamio-cli/internal/apierr"
+	"github.com/Andamio-Platform/andamio-cli/internal/cardano"
 	"github.com/Andamio-Platform/andamio-cli/internal/client"
 	"github.com/Andamio-Platform/andamio-cli/internal/config"
 	"github.com/Andamio-Platform/andamio-cli/internal/output"

--- a/cmd/andamio/tx_lifecycle.go
+++ b/cmd/andamio/tx_lifecycle.go
@@ -209,7 +209,16 @@ func executeTxLifecycle(c *client.Client, cfg *config.Config, params TxLifecycle
 	if err != nil {
 		if !isJSON {
 			fmt.Fprintf(os.Stderr, "  TX hash: %s\n", signResult.TxHash)
-			fmt.Fprintf(os.Stderr, "\nCheck later: andamio tx status %s\n", signResult.TxHash)
+			if finalState == "failed" {
+				fmt.Fprintf(os.Stderr, "\nTransaction confirmed on-chain but DB update failed.\n")
+				fmt.Fprintf(os.Stderr, "The on-chain state is authoritative — the gateway will retry automatically.\n")
+				fmt.Fprintf(os.Stderr, "\nDiagnostics:\n")
+				fmt.Fprintf(os.Stderr, "  andamio tx status %s\n", signResult.TxHash)
+				fmt.Fprintf(os.Stderr, "\nIf the state remains 'failed', re-register to retry:\n")
+				fmt.Fprintf(os.Stderr, "  andamio tx register --tx-hash %s --tx-type %s\n", signResult.TxHash, params.TxType)
+			} else {
+				fmt.Fprintf(os.Stderr, "\nCheck later: andamio tx status %s\n", signResult.TxHash)
+			}
 		}
 		return result, fail(finalState, "poll failed", err)
 	}

--- a/cmd/andamio/tx_run.go
+++ b/cmd/andamio/tx_run.go
@@ -236,7 +236,7 @@ func pollTxStatus(ctx context.Context, c *client.Client, txHash string, timeout 
 			case "updated":
 				return state, nil
 			case "failed":
-				return state, fmt.Errorf("transaction confirmed but DB update failed")
+				return state, fmt.Errorf("transaction confirmed on-chain but DB update failed — see recovery steps above")
 			case "expired":
 				return state, fmt.Errorf("transaction expired without confirmation")
 			}

--- a/cmd/andamio/tx_run.go
+++ b/cmd/andamio/tx_run.go
@@ -236,7 +236,7 @@ func pollTxStatus(ctx context.Context, c *client.Client, txHash string, timeout 
 			case "updated":
 				return state, nil
 			case "failed":
-				return state, fmt.Errorf("transaction confirmed on-chain but DB update failed — see recovery steps above")
+				return state, fmt.Errorf("transaction confirmed on-chain but DB update failed")
 			case "expired":
 				return state, fmt.Errorf("transaction expired without confirmation")
 			}

--- a/docs/COURSE-LIFECYCLE.md
+++ b/docs/COURSE-LIFECYCLE.md
@@ -1,0 +1,358 @@
+# Course Lifecycle
+
+Step-by-step guide for creating and managing courses with the Andamio CLI, ensuring on-chain and off-chain (database) state stay in sync throughout.
+
+For the underlying transaction pipeline and recovery procedures, see [TX-LIFECYCLE.md](TX-LIFECYCLE.md).
+
+## Prerequisites
+
+Before starting, configure the CLI with all required credentials:
+
+```bash
+# Store your API key (read access)
+andamio auth login --api-key <your-api-key>
+
+# Authenticate with your wallet (edit access)
+andamio user login
+
+# Set the Cardano submit endpoint
+andamio config set-submit-url https://cardano-preprod.blockfrost.io/api/v0/tx/submit
+
+# If using Blockfrost, set the project ID header
+andamio config set-submit-header project_id <your-blockfrost-project-id>
+```
+
+You also need a Cardano `.skey` file for signing transactions.
+
+Verify your setup:
+
+```bash
+andamio user status
+andamio config show
+```
+
+## Module Status Lifecycle
+
+Modules move through three states. Understanding these states is critical for knowing which operations are allowed at each stage.
+
+```
+DRAFT --> APPROVED/ON_CHAIN
+```
+
+| Status | SLTs editable? | Content editable? | How it transitions |
+|--------|---------------|-------------------|-------------------|
+| **DRAFT** | Yes | Yes | Created by `course import --create`. Full import works. |
+| **APPROVED** | No (locked) | Yes | Set by `register-module` or automatic gateway sync after `modules_manage` TX. |
+| **ON_CHAIN** | No (locked) | Yes | Set by `publish-module`. Module has on-chain counterpart and merged DB record. |
+
+Once SLTs are locked, `course import` skips sending SLT data to avoid `SLT_LOCKED` errors. Lessons, introduction, and assignment content remain editable at all statuses.
+
+## Course Creation Workflow
+
+### Step 1: Create course on-chain
+
+Mint the course instance on Cardano. The `tx run` command handles the full build-sign-submit-register-poll pipeline.
+
+```bash
+andamio tx run /v2/tx/instance/owner/course/create \
+  --body '{"alias":"<your-alias>"}' \
+  --skey ./payment.skey \
+  --tx-type course_create \
+  --instance-id <course-id>
+```
+
+The build response includes the `course_id`. Save it -- every subsequent command references it.
+
+**Verify**: Wait for `state: updated` in the poll output, confirming both chain and DB are in sync.
+
+### Step 2: Register course in the database
+
+Create the off-chain course record with metadata:
+
+```bash
+andamio course owner register --course-id <course-id> --title "My Course"
+```
+
+Optional flags: `--description`, `--image-url`, `--video-url`, `--category`, `--public`.
+
+**Verify**: Confirm the course exists:
+
+```bash
+andamio course get <course-id>
+```
+
+### Step 3: Prepare module content locally
+
+Create a compiled module directory with the following structure:
+
+```
+compiled/my-course/101/
+  outline.md            # Required: frontmatter + SLT list
+  lesson-1.md           # One per SLT
+  lesson-2.md
+  introduction.md       # Optional
+  assignment.md         # Optional
+  assets/               # Optional: images
+    diagram.png
+```
+
+**outline.md** format:
+
+```markdown
+---
+title: "Module 101: Foundations"
+code: "101"
+description: "Introduction to core concepts"
+image_url: ""
+video_url: ""
+---
+
+## SLTs
+
+1. Describe the protocol architecture
+2. Build a basic transaction
+3. Verify credential hashes
+```
+
+Each `lesson-N.md` corresponds to the Nth SLT. The first `# Heading` in each file becomes the lesson title; the remaining content becomes the body.
+
+### Step 4: Import content to create a DRAFT module
+
+Import the compiled directory. The `--create` flag creates the module if it does not already exist in the database:
+
+```bash
+andamio course import ./compiled/my-course/101 --course-id <course-id> --create
+```
+
+This command:
+1. Parses `outline.md` to extract the module code, SLTs, and metadata.
+2. Creates the module in **DRAFT** status.
+3. Computes and stores the SLT hash (Blake2b-256 of the Plutus-encoded SLT list).
+4. Uploads lessons, introduction, and assignment content.
+5. Uploads any new images from `assets/` to the CDN.
+
+Note the SLT hash from the output. You can also compute it independently:
+
+```bash
+andamio course credential compute-hash --file ./compiled/my-course/101/outline.md
+```
+
+**Verify**: Check that the module appears:
+
+```bash
+andamio course modules <course-id>
+```
+
+### Step 5: Mint modules on-chain
+
+Submit the on-chain transaction to register modules with the Cardano validators. The SLT texts in the body must exactly match what was imported in Step 4.
+
+```bash
+andamio tx run /v2/tx/course/teacher/modules/manage \
+  --body '{"alias":"<your-alias>","course_id":"<course-id>","modules":[{"module_code":"101","slts":["Describe the protocol architecture","Build a basic transaction","Verify credential hashes"]}]}' \
+  --skey ./payment.skey \
+  --tx-type modules_manage
+```
+
+When the transaction confirms, the gateway attempts to match the on-chain module to the existing DB record by SLT hash. If the hash matches, the module status advances automatically.
+
+**Verify**: A `state: updated` response means the gateway successfully matched and synced. Proceed to Step 7.
+
+If the response shows `state: failed`, the gateway could not match the module. Proceed to Step 6.
+
+### Step 6: Register module (recovery only)
+
+This step is only needed if Step 5 returned `state: failed`, meaning the gateway could not automatically link the on-chain module to the DB record.
+
+Manually link them by providing the SLT hash:
+
+```bash
+andamio course teacher register-module \
+  --course-id <course-id> \
+  --module-code 101 \
+  --slt-hash <hash-from-step-4>
+```
+
+This sets the module status to **APPROVED**, which locks SLTs.
+
+### Step 7: Publish module
+
+Publish the module to finalize its on-chain/off-chain link:
+
+```bash
+andamio course teacher publish-module --course-id <course-id> --module-code 101
+```
+
+Look for a "merged" source signal in the response, which confirms the on-chain and DB records are fully synchronized.
+
+### Step 8: Update content (ongoing)
+
+After modules are published, you can continue updating lessons, introduction, and assignment content. SLTs are locked and will be skipped automatically.
+
+```bash
+andamio course import ./compiled/my-course/101 --course-id <course-id>
+```
+
+To import all modules in a course at once:
+
+```bash
+andamio course import-all ./compiled/my-course --course-id <course-id>
+```
+
+## Student Enrollment and Assignments
+
+### Enroll in a course module (on-chain)
+
+```bash
+andamio tx run /v2/tx/course/student/enroll \
+  --body '{"alias":"<student-alias>","course_id":"<course-id>","course_module_code":"101"}' \
+  --skey ./payment.skey \
+  --tx-type course_enroll
+```
+
+### Submit assignment evidence
+
+```bash
+andamio course student submit \
+  --course-id <course-id> \
+  --module-code 101 \
+  --evidence-file ./evidence.md
+```
+
+Or inline:
+
+```bash
+andamio course student submit \
+  --course-id <course-id> \
+  --module-code 101 \
+  --evidence "Completed all exercises. See repo: https://github.com/..."
+```
+
+### Teacher reviews a submission
+
+```bash
+andamio course teacher review \
+  --course-id <course-id> \
+  --module-code 101 \
+  --participant-alias <student-alias> \
+  --decision accept
+```
+
+List pending reviews:
+
+```bash
+andamio course teacher commitments --course-id <course-id>
+```
+
+### Claim credential (on-chain)
+
+After the teacher accepts the submission:
+
+```bash
+andamio tx run /v2/tx/course/student/credential/claim \
+  --body '{"alias":"<student-alias>","course_id":"<course-id>","course_module_code":"101"}' \
+  --skey ./payment.skey \
+  --tx-type credential_claim
+```
+
+## Verifying Hashes
+
+SLT hashes are the link between on-chain modules and their database records. Use these commands to verify integrity.
+
+### Compute hash from local content
+
+From individual SLT flags:
+
+```bash
+andamio course credential compute-hash \
+  --slt "Describe the protocol architecture" \
+  --slt "Build a basic transaction" \
+  --slt "Verify credential hashes"
+```
+
+From an outline file:
+
+```bash
+andamio course credential compute-hash --file ./compiled/my-course/101/outline.md
+```
+
+Add `--output json` for structured output including the hash, SLT count, and SLT texts.
+
+### Verify against on-chain data
+
+Compare locally computed hashes against the API-stored values for all modules in a course:
+
+```bash
+andamio course credential verify-hash <course-id>
+```
+
+This fetches each module's SLTs from the API, re-computes the hash, and reports mismatches.
+
+## Troubleshooting
+
+### "Module not found" after `modules_manage` TX
+
+**Cause**: The gateway could not find a DB module with a matching SLT hash when the on-chain transaction confirmed. This happens when the module was never imported (no DB record), or the SLTs in the TX body do not match the imported SLTs.
+
+**Fix**: Always import content first (Step 4), which computes and stores the hash, before minting on-chain (Step 5). Ensure the SLT texts in the `tx run` body exactly match the outline.
+
+If the TX already confirmed, use `register-module` (Step 6) to manually link the records.
+
+### "slt_index out of range"
+
+**Cause**: The module was registered (status is APPROVED) but has no SLT records in the database. This can happen if `register-module` was called before content was imported.
+
+**Fix**: Reset the module to DRAFT, import content, then re-register:
+
+```bash
+andamio course teacher update-module-status \
+  --course-id <course-id> \
+  --module-code 101 \
+  --status DRAFT
+
+andamio course import ./compiled/my-course/101 --course-id <course-id>
+```
+
+### "course_module_code already exists" on register-module
+
+**Cause**: A module with that code already exists in the database, created by a prior `course import --create`.
+
+**Fix**: If the existing module's SLT hash matches the on-chain module, skip `register-module` -- the gateway should have synced automatically. If it does not match, delete the module and re-import with correct SLTs:
+
+```bash
+andamio course teacher delete-module --course-id <course-id> --module-code 101
+andamio course import ./compiled/my-course/101 --course-id <course-id> --create
+```
+
+### TX confirmed but DB update failed
+
+The transaction is on-chain but the database did not sync. This is the `failed` terminal state in the TX pipeline.
+
+The gateway has automatic recovery mechanisms (retries, state healer, abandoned TX reconciler). Check the current status:
+
+```bash
+andamio tx status <tx-hash>
+```
+
+See [TX-LIFECYCLE.md](TX-LIFECYCLE.md) for detailed recovery procedures.
+
+### SLTs differ between local content and on-chain
+
+If `verify-hash` reports mismatches, the local SLTs were modified after minting. On-chain state is the source of truth. Update local content to match, or use `verify-hash --output json` to inspect the exact differences.
+
+## Quick Reference
+
+Recommended sequence for creating a course with modules:
+
+| Step | Command | Result |
+|------|---------|--------|
+| 1 | `tx run .../course/create` | Course minted on-chain, DB record created |
+| 2 | `course owner register` | Course metadata stored in DB |
+| 3 | Prepare `outline.md`, `lesson-N.md` files | Local content ready |
+| 4 | `course import --create` | DRAFT module in DB with SLT hash |
+| 5 | `tx run .../modules/manage` | Modules minted on-chain, gateway syncs by hash |
+| 6 | `course teacher register-module` | (Recovery only) Manual hash link if Step 5 failed |
+| 7 | `course teacher publish-module` | Module fully published, on-chain + DB merged |
+| 8 | `course import` (no `--create`) | Update content anytime (SLTs locked, content open) |
+
+Key principle: **always create the DB record before the on-chain record**. The gateway matches them by SLT hash. If the DB module does not exist or has a different hash when the on-chain TX confirms, the automatic sync fails and manual recovery is needed.

--- a/docs/PROJECT-LIFECYCLE.md
+++ b/docs/PROJECT-LIFECYCLE.md
@@ -1,0 +1,297 @@
+# Project Lifecycle
+
+Step-by-step guide for creating and managing Andamio projects through the CLI. Projects follow the same transaction pipeline as courses (see [TX-LIFECYCLE.md](TX-LIFECYCLE.md)) but are simpler -- tasks replace modules, contributors replace students, and there is no SLT hash complexity.
+
+## Prerequisites
+
+Before starting, you need:
+
+1. **API key** -- stored via `andamio auth login --api-key <key>`
+2. **User JWT** -- obtained via `andamio user login` (browser wallet signing) or `andamio user login --skey <path> --alias <name>` (headless)
+3. **Submit URL** -- configured via `andamio config set-submit-url <url>` (e.g., Blockfrost submit endpoint)
+4. **Submit headers** -- if required by your submit provider: `andamio config set-submit-header project_id <blockfrost-id>`
+5. **Signing key** -- a Cardano `.skey` file for transaction signing
+
+Verify your setup:
+
+```bash
+andamio user status
+andamio config show
+```
+
+## Project Creation Workflow
+
+### Step 1: Create project on-chain
+
+Build, sign, submit, and register the project creation transaction:
+
+```bash
+andamio tx run /v2/tx/instance/owner/project/create \
+  --body '{"alias":"<your-alias>"}' \
+  --skey ./payment.skey \
+  --tx-type project_create \
+  --instance-id <project-id>
+```
+
+Wait for the command to report `updated` status. This means the transaction is confirmed on-chain and the database has synced. See [TX-LIFECYCLE.md](TX-LIFECYCLE.md) for details on transaction states and recovery.
+
+### Step 2: Register project metadata
+
+Link the on-chain project to off-chain metadata:
+
+```bash
+andamio project owner register --project-id <project-id> --title "My Project"
+```
+
+### Step 3: Update project metadata (optional)
+
+Add description, images, and visibility settings:
+
+```bash
+andamio project owner update --project-id <project-id> \
+  --title "My Project" \
+  --description "A detailed description of the project" \
+  --image-url "https://example.com/image.png" \
+  --video-url "https://example.com/video.mp4" \
+  --category "development" \
+  --public
+```
+
+Only flags you include are sent -- omitted fields remain unchanged.
+
+### Verify creation
+
+```bash
+andamio project get <project-id>
+andamio project owner list
+```
+
+## Task Management
+
+Tasks are the work units within a project. They are created off-chain first, then minted on-chain when ready.
+
+### Create tasks
+
+```bash
+andamio project task create <project-id> \
+  --title "Fix login bug" \
+  --lovelace 5000000 \
+  --expiration 2026-06-01
+
+andamio project task create <project-id> \
+  --title "Write API documentation" \
+  --lovelace 3000000 \
+  --expiration 2026-07-01
+```
+
+### List tasks
+
+```bash
+# Manager view (includes draft tasks)
+andamio project task list <project-id>
+
+# Public view
+andamio project tasks <project-id>
+```
+
+### Export tasks to local files
+
+Export all tasks as Markdown files for local editing:
+
+```bash
+andamio project task export <project-id>
+```
+
+This creates a `tasks/<project-slug>/` directory with one Markdown file per task.
+
+### Edit and reimport
+
+After editing the exported Markdown files locally:
+
+```bash
+# Preview changes without applying
+andamio project task import <project-id> --dry-run
+
+# Apply changes
+andamio project task import <project-id>
+```
+
+### Mint tasks on-chain
+
+Once tasks are finalized, mint them on-chain:
+
+```bash
+andamio tx run /v2/tx/project/manager/tasks/manage \
+  --body '{"alias":"<your-alias>","project_id":"<project-id>","tasks":[...]}' \
+  --skey ./payment.skey \
+  --tx-type tasks_manage
+```
+
+### Update and delete draft tasks
+
+```bash
+# Update a task by index
+andamio project task update <task-index> --project-id <project-id> \
+  --title "Updated title" \
+  --lovelace 8000000
+
+# Delete a draft task
+andamio project task delete <task-index> --project-id <project-id>
+```
+
+## Contributor Workflow
+
+Contributors discover projects, commit to tasks, submit evidence, and claim credentials.
+
+### Discover and commit
+
+```bash
+# List projects you can contribute to
+andamio project contributor list
+
+# View available tasks
+andamio project tasks <project-id>
+
+# Commit to a task (on-chain)
+andamio tx run /v2/tx/project/contributor/commit \
+  --body '{"alias":"<your-alias>","project_id":"<project-id>","task_index":1}' \
+  --skey ./payment.skey \
+  --tx-type project_join
+```
+
+### Submit evidence
+
+```bash
+# Submit from a Markdown file
+andamio project contributor update \
+  --project-id <project-id> \
+  --task-index 1 \
+  --evidence-file work.md
+
+# Or submit inline
+andamio project contributor update \
+  --project-id <project-id> \
+  --task-index 1 \
+  --evidence "Completed the fix. PR: https://github.com/org/repo/pull/42"
+```
+
+### Check commitment status
+
+```bash
+# List all your commitments
+andamio project contributor commitments
+
+# Get a specific commitment
+andamio project contributor commitment \
+  --project-id <project-id> \
+  --task-index 1
+```
+
+### Manager assessment
+
+The project manager reviews submitted work and assesses tasks on-chain:
+
+```bash
+# List pending assessments
+andamio project manager commitments --project-id <project-id>
+
+# Assess tasks (on-chain)
+andamio tx run /v2/tx/project/manager/tasks/assess \
+  --body '{"alias":"<your-alias>","project_id":"<project-id>","assessment_decisions":[...]}' \
+  --skey ./payment.skey \
+  --tx-type task_assess
+```
+
+### Claim credential
+
+After a task is assessed and approved, the contributor claims their credential on-chain:
+
+```bash
+andamio tx run /v2/tx/project/contributor/credential/claim \
+  --body '{"alias":"<your-alias>","project_id":"<project-id>"}' \
+  --skey ./payment.skey \
+  --tx-type project_credential_claim
+```
+
+## Verifying Task Hashes
+
+Task hashes provide on-chain integrity verification. Use these commands to compute and verify hashes locally.
+
+### Compute a hash from task content
+
+```bash
+andamio project task compute-hash \
+  --content "Fix login bug" \
+  --lovelace 5000000 \
+  --expiration 2026-06-01
+```
+
+Or compute from a task file:
+
+```bash
+andamio project task compute-hash --file tasks/my-project/001-fix-login-bug.md
+```
+
+### Verify hashes against on-chain data
+
+```bash
+andamio project task verify-hash <project-id>
+```
+
+This compares the locally computed hashes against the on-chain values and reports any mismatches.
+
+## Troubleshooting
+
+### TX confirmed but database not updated
+
+The transaction reached `confirmed` state but never moved to `updated`. The gateway has automatic recovery mechanisms (state machine retries, state healer, abandoned TX reconciler). See the Recovery Procedures section in [TX-LIFECYCLE.md](TX-LIFECYCLE.md).
+
+```bash
+andamio tx status <tx-hash>
+```
+
+### Task hash mismatch
+
+If `verify-hash` reports mismatches, the gateway self-heals by adopting on-chain hashes as the source of truth. No manual intervention is needed -- the mismatch will resolve on the next API read.
+
+### Evidence submission fails
+
+Check that your JWT session is still valid:
+
+```bash
+andamio user status
+```
+
+If the session has expired, re-authenticate:
+
+```bash
+andamio user login
+```
+
+### Task import fails
+
+Ensure you are authenticated with a JWT (not just an API key) and that you have manager permissions for the project:
+
+```bash
+andamio user status
+andamio project owner list
+```
+
+## Quick Reference
+
+Recommended project lifecycle sequence from creation to contributor credential:
+
+| Step | Role | Command | On-chain? |
+|------|------|---------|-----------|
+| 1 | Owner | `tx run .../project/create` | Yes |
+| 2 | Owner | `project owner register` | No |
+| 3 | Owner | `project owner update` | No |
+| 4 | Manager | `project task create` | No |
+| 5 | Manager | `project task export` / edit / `project task import` | No |
+| 6 | Manager | `tx run .../tasks/manage` | Yes |
+| 7 | Contributor | `tx run .../contributor/commit` | Yes |
+| 8 | Contributor | `project contributor update --evidence-file` | No |
+| 9 | Manager | `tx run .../tasks/assess` | Yes |
+| 10 | Contributor | `tx run .../contributor/credential/claim` | Yes |
+
+Steps 1, 6, 7, 9, and 10 are on-chain transactions that follow the 5-step pipeline described in [TX-LIFECYCLE.md](TX-LIFECYCLE.md). All other steps are off-chain API calls or local operations.

--- a/docs/TX-LIFECYCLE.md
+++ b/docs/TX-LIFECYCLE.md
@@ -1,0 +1,190 @@
+# Transaction Lifecycle
+
+Reference for the Andamio CLI transaction pipeline: how transactions move from build to on-chain confirmation, how the database stays in sync, and how to recover from failures.
+
+## The 5-Step Pipeline
+
+Every Andamio transaction follows this pipeline. The `tx run` command executes all five steps. The individual `tx build`, `tx sign`, `tx submit`, `tx register`, and `tx status` commands expose each step for scripting.
+
+```
+BUILD --> SIGN --> SUBMIT --> REGISTER --> POLL
+```
+
+### 1. BUILD
+
+```
+POST /api/v2/tx/{endpoint}
+```
+
+The gateway forwards the request to the Atlas TX builder (Haskell), which constructs a balanced Cardano transaction and returns `unsigned_tx` as CBOR hex.
+
+```bash
+andamio tx build course/enroll --body '{"course_id":"abc"}'
+```
+
+### 2. SIGN
+
+Local operation. Loads the `.skey` file via `cardano.LoadSigningKey`, extracts the raw CBOR body bytes (preserving original encoding), hashes with Blake2b-256, signs with ed25519, and assembles VKey witnesses (merging into any existing witness set).
+
+```bash
+andamio tx sign --tx <unsigned_hex> --skey payment.skey
+```
+
+### 3. SUBMIT
+
+Posts the signed transaction as `application/cbor` to the configured submit endpoint. The submit URL and headers are set via `config set-submit-url` and `config set-submit-header` (e.g., for Blockfrost).
+
+```bash
+andamio tx submit --tx <signed_hex>
+```
+
+### 4. REGISTER
+
+```
+POST /api/v2/tx/register
+```
+
+Registers the submitted transaction with the gateway for tracking. The payload includes `tx_hash`, `tx_type`, and optionally `instance_id` and `metadata`. This is what connects the on-chain transaction to the off-chain database update pipeline.
+
+```bash
+andamio tx register --tx-hash <hash> --tx-type course_enroll
+```
+
+### 5. POLL
+
+Polls `GET /api/v2/tx/status/{hash}` every 5 seconds until the transaction reaches a terminal state.
+
+```bash
+andamio tx status <hash>
+```
+
+## Transaction States
+
+```mermaid
+stateDiagram-v2
+    [*] --> pending : registered
+    pending --> confirmed : on-chain
+    pending --> expired : 2h timeout
+    confirmed --> updated : DB synced
+    confirmed --> failed : DB retries exhausted
+    updated --> [*]
+    expired --> [*]
+    failed --> [*]
+```
+
+### Terminal States
+
+| State | Meaning | On-chain? | DB synced? |
+|-------|---------|-----------|------------|
+| `updated` | Success. Chain confirmed and database updated. | Yes | Yes |
+| `failed` | Chain confirmed but the DB update failed after 5 retries (30s base backoff). | Yes | No |
+| `expired` | Transaction was never confirmed on-chain within 2 hours. | No | No |
+
+## Recovery Procedures
+
+### State: `failed`
+
+The transaction IS on-chain. The database update failed after exhausting retries. The gateway has three layers of recovery that operate without CLI intervention:
+
+1. **State machine retries** -- automatic retries with exponential backoff (5 attempts, 30s base).
+2. **State healer** -- fixes drift when the resource is next read through the API.
+3. **Abandoned TX reconciler** -- background process that reconciles unresolved transactions.
+
+On-chain state is the source of truth. The database will eventually converge. Check current status:
+
+```bash
+andamio tx status <hash>
+```
+
+### State: `expired`
+
+The transaction was never confirmed on-chain within the 2-hour window. This usually means the transaction was never actually submitted, was rejected by the network, or the slot validity interval passed.
+
+```bash
+# Check if it appeared late
+andamio tx status <hash>
+
+# If truly lost, rebuild and resubmit
+andamio tx run <endpoint> --skey payment.skey --tx-type <type> --body '...'
+```
+
+### Register failure
+
+The transaction was submitted and is on-chain, but the register call failed (network error, timeout, etc.). The gateway does not know about it.
+
+```bash
+andamio tx register --tx-hash <hash> --tx-type <type>
+```
+
+### SIGINT during polling
+
+If you interrupt `tx run` during the poll step, the transaction may already be submitted and registered. Polling is read-only -- interrupting it has no side effects.
+
+```bash
+andamio tx status <hash>
+```
+
+## Diagnostic Commands
+
+| Command | Purpose |
+|---------|---------|
+| `andamio tx status <hash>` | Check current state of a transaction |
+| `andamio tx pending` | List all tracked transactions |
+| `andamio tx types` | List valid transaction types |
+| `andamio tx register --tx-hash <hash> --tx-type <type>` | Re-register a transaction the gateway lost track of |
+
+## Transaction Types
+
+| # | Transaction | `tx_type` | Role | DB Update? |
+|---|-------------|-----------|------|------------|
+| 1 | Mint Access Token | `access_token_mint` | User | No |
+| 2 | Create Course | `course_create` | Owner | Yes |
+| 3 | Course Enroll | `course_enroll` | Student | No |
+| 4 | Manage Teachers | `teachers_update` | Owner | Yes |
+| 5 | Manage Modules | `modules_manage` | Teacher | Yes |
+| 6 | Submit Assignment | `assignment_submit` | Student | Yes |
+| 7 | Assess Assignments | `assessment_assess` | Teacher | Yes |
+| 8 | Claim Course Credential | `credential_claim` | Student | No |
+| 9 | Create Project | `project_create` | Owner | Yes |
+| 10 | Manage Managers | `managers_manage` | Owner | Yes |
+| 11 | Manage Blacklist | `blacklist_update` | Owner | No |
+| 12 | Manage Tasks | `tasks_manage` | Manager | Yes |
+| 13 | Commit to Task | `project_join` | Contributor | Yes |
+| 14 | Submit Task Work | `task_submit` | Contributor | Yes |
+| 15 | Assess Tasks | `task_assess` | Manager | Yes |
+| 16 | Claim Project Credential | `project_credential_claim` | Contributor | Yes |
+| 17 | Fund Treasury | `treasury_fund` | User | No |
+
+Transactions with "DB Update? No" reach terminal state as soon as they are confirmed on-chain. Transactions with "DB Update? Yes" require an additional database synchronization step before reaching the `updated` state.
+
+## The `tx run` Command
+
+`tx run` wraps the entire 5-step pipeline into a single invocation:
+
+```bash
+andamio tx run course/enroll \
+  --skey payment.skey \
+  --tx-type course_enroll \
+  --body '{"course_id":"abc","course_module_code":"mod01"}'
+```
+
+It builds, signs, submits, registers, and polls -- printing progress to stderr and the final result to stdout.
+
+**Flags:**
+
+- `--skey <path>` -- Path to the Cardano `.skey` file (required).
+- `--tx-type <type>` -- Transaction type for registration (required).
+- `--body <json>` / `--body-file <path>` -- Build request payload.
+- `--no-wait` -- Submit and register but skip polling. Useful in CI or when you will check status later.
+- `--timeout <duration>` -- Override the default poll timeout.
+- `--metadata <json>` -- Additional metadata for registration.
+- `--instance-id <id>` -- Instance identifier for registration.
+
+With `--no-wait`, the command exits after registration. Use `andamio tx status <hash>` to check the result later.
+
+## Key Principles
+
+- **On-chain state is the source of truth.** The database is a read-optimized projection. If they disagree, the chain wins.
+- **All DB updates are idempotent.** Re-registering a transaction or triggering a re-sync will not produce duplicate state.
+- **Each step is independently scriptable.** `tx build`, `tx sign`, `tx submit`, `tx register`, and `tx status` can be composed in shell scripts, CI pipelines, or agent workflows.
+- **Never combine on-chain TX with off-chain API calls in a single operation.** Build and submit the transaction first. Once confirmed, make any off-chain API calls. Mixing them risks partial state if either side fails.

--- a/docs/plans/2026-04-03-001-docs-chain-db-sync-lifecycle-plan.md
+++ b/docs/plans/2026-04-03-001-docs-chain-db-sync-lifecycle-plan.md
@@ -1,0 +1,282 @@
+---
+title: "docs: document chain/DB sync model and course/project lifecycle workflows"
+type: feat
+status: completed
+date: 2026-04-03
+---
+
+# docs: document chain/DB sync model and course/project lifecycle workflows
+
+## Overview
+
+Create user-facing documentation for the chain/DB synchronization model and correct CLI command sequences for course and project lifecycles. Improve CLI error messages so that sync failures guide users toward recovery instead of dead-ending. Make `course import` compute and store SLT hashes so the natural import→mint→sync workflow doesn't require manual hash gymnastics.
+
+## Problem Frame
+
+An experienced developer using the CLI cannot figure out the correct sequence of commands to create a course or project with full chain + DB consistency. The two state systems (on-chain Cardano, off-chain DB) have an implicit sync model that is undocumented. Getting the ordering wrong produces silent failures: transactions confirm on-chain but DB updates fail, leaving orphaned state. Issue #52 documents 10 failed transactions across 4 different workflow attempts before the user pieced together the correct flow.
+
+The root cause is a circular dependency: the DB needs a module record with a matching SLT hash before the on-chain TX confirms, but there's no documented (or easy) way to set that hash on a DRAFT module before minting.
+
+## Requirements Trace
+
+- R1. Document the TX lifecycle (BUILD→SIGN→SUBMIT→REGISTER→CONFIRM→UPDATE) with terminal states and recovery paths
+- R2. Document the correct course lifecycle: from course creation through module publishing with exact CLI commands
+- R3. Document the correct project lifecycle: from project creation through task management
+- R4. Document recovery procedures when `tx run` returns "transaction confirmed but DB update failed"
+- R5. Make `course import` compute SLT hashes via `ComputeSltHash()` and include them in the update payload
+- R6. Improve `tx run` error messages for the `"failed"` state to include tx_hash, tx_type, and recovery hints
+- R7. All documentation must be in `docs/` within the CLI repo (developer-facing reference)
+
+## Scope Boundaries
+
+- **Not in scope**: Server-side API changes (e.g., making `register-module` work as upsert — suggestion #3 from the issue). Those belong in `andamio-api` issues.
+- **Not in scope**: `--verify-db` pre-flight flag for `tx run` (suggestion #6) — larger feature, separate issue.
+- **Not in scope**: Changes to the `andamio-api` gateway or `andamio-db-api-go`.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `cmd/andamio/tx_run.go` — `RunResult` struct, `pollTxStatus` with terminal states at lines 235-242, `fail()` closure for partial progress reporting
+- `cmd/andamio/tx_lifecycle.go` — Five-step pipeline: build, sign, submit, register, poll
+- `cmd/andamio/course_import.go` — SLT locking check at line 245 (`sltsLocked := existing.Status != "DRAFT"`), `updateModuleContent` at line 1116
+- `cmd/andamio/course_teacher_ops.go` — `runCourseTeacherRegisterModule` at line 123, `runCourseTeacherPublishModule` at line 161 (checks `source: "merged"`)
+- `internal/cardano/slt_hash.go` — `ComputeSltHash(slts []string) string`
+- `internal/cardano/task_hash.go` — `ComputeTaskHash(task TaskData) (string, error)`
+
+### Institutional Learnings
+
+- **TX state machine pattern** (`docs/solutions/architecture/cli-tx-state-machine-pattern-and-task-hash-verification.md`): No CLI command should combine `executeTxLifecycle` with a separate off-chain API POST. Off-chain operations are separate commands.
+- **Three-layer recovery** (andamio-api docs): (1) TX state machine primary path, (2) state healer forward-corrections on reads, (3) abandoned TX recovery via reconcilers.
+- **On-chain-as-source-of-truth** (andamio-api task hash self-healing): Chain is authoritative. The gateway's self-healing pattern adopts on-chain hashes and corrects DB records to match.
+- **PBL retro** (`docs/solutions/developer-experience/cli-midnight-pbl-retro-fixes.md`): `register-module` sets APPROVED, but `import` requires DRAFT for SLTs. Users get "slt_index out of range" with no guidance. Need `update-module-status --status DRAFT` as workaround.
+- **API payload semantics** (import parity solution doc): Omit = unchanged, empty array = delete all. Critical for import/update operations.
+- **Module status flow**: DRAFT (SLTs editable) → APPROVED (after register-module, SLTs locked) → ON_CHAIN (after publish). Lessons/intro/assignment remain editable in all states.
+
+## Key Technical Decisions
+
+- **SLT hash computation in import**: The hash will be computed locally using `ComputeSltHash()` (already available in `internal/cardano/`) and included in the module update payload as `slt_hash`. This is a non-breaking addition — the API already accepts `slt_hash` on the update endpoint. The hash is computed from the same SLT text strings the import already sends, so consistency is guaranteed.
+
+- **Error message improvement scope**: Only the `"failed"` terminal state in `pollTxStatus` needs improvement. The register-failure path already has good recovery guidance (line 175-179 suggests `andamio tx register`). The `"failed"` path should mirror that pattern.
+
+- **Documentation format**: User-facing workflow guides go in `docs/` as standalone Markdown files (not in `docs/solutions/` which is for post-mortem learnings). Two guides: one for the sync model, one for lifecycles with exact commands.
+
+- **Project lifecycle included**: The project lifecycle is structurally simpler (no SLT hash complication) but follows the same TX lifecycle pattern. Documenting it alongside courses prevents the same confusion.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should import auto-set module status to APPROVED after hash computation?** No. Setting the hash on the update payload is sufficient for the API to match during sync. Status transitions should remain explicit user actions.
+- **Where do the docs live?** In `docs/` within the CLI repo. The cross-repo docs site (`andamio-docs`) already has CLI guides; these are complementary developer references.
+
+### Deferred to Implementation
+
+- **Exact API response when `slt_hash` is included in the update payload**: Need to verify the API accepts it on the `course-module/update` endpoint (vs only on `register`). If not accepted, the hash can be logged/displayed for manual use.
+- **Project lifecycle exact TX types**: Need to verify the full set of project TX types from `andamio tx types` output.
+
+## Implementation Units
+
+- [ ] **Unit 1: Document the TX lifecycle and chain/DB sync model**
+
+  **Goal:** Create a reference document explaining how chain/DB synchronization works
+
+  **Requirements:** R1, R4
+
+  **Dependencies:** None
+
+  **Files:**
+  - Create: `docs/TX-LIFECYCLE.md`
+
+  **Approach:**
+  - Document the 5-step pipeline: build → sign → submit → register → poll
+  - Document terminal states: `updated` (success), `failed` (chain OK, DB failed), `expired` (never confirmed)
+  - Document the three-layer recovery model: state machine → healer → reconciler
+  - Document what `"failed"` means and recovery steps (re-register, check status, manual reconciliation)
+  - Include a state diagram showing transitions
+  - Reference `andamio tx status`, `andamio tx register`, `andamio tx pending` as diagnostic/recovery tools
+
+  **Patterns to follow:**
+  - `andamio-api/docs/TX_LIFECYCLE_REFERENCE.md` for the authoritative server-side reference
+  - `docs/solutions/architecture/cli-tx-state-machine-pattern-and-task-hash-verification.md` for CLI-specific patterns
+
+  **Test scenarios:**
+  - Document accurately reflects all terminal states in `tx_run.go`
+  - Recovery steps are actionable CLI commands
+  - No contradiction with existing solution docs
+
+  **Verification:**
+  - Document covers all 5 steps, all 3 terminal states, and recovery for each failure mode
+
+- [ ] **Unit 2: Document course lifecycle workflow**
+
+  **Goal:** Step-by-step guide for creating a course with full chain + DB consistency
+
+  **Requirements:** R2
+
+  **Dependencies:** Unit 1 (references TX lifecycle)
+
+  **Files:**
+  - Create: `docs/COURSE-LIFECYCLE.md`
+
+  **Approach:**
+  - Document the correct sequence: create course on-chain → import content → compute/set SLT hash → mint modules on-chain → register-module → publish-module → enroll students
+  - Show exact CLI commands at each step with placeholder values
+  - Document module status transitions (DRAFT → APPROVED → ON_CHAIN) and what's editable at each stage
+  - Call out the `register-module` → APPROVED status gotcha and the `update-module-status --status DRAFT` workaround
+  - Include troubleshooting section for common failures (from issue #52's transaction log)
+  - Cross-reference TX-LIFECYCLE.md for recovery
+
+  **Patterns to follow:**
+  - Composability pattern: commands shown in pipeable form with `--output json | jq`
+  - Existing CLAUDE.md command reference for accurate flags
+
+  **Test scenarios:**
+  - Every CLI command in the guide is a real command with correct flags
+  - The sequence doesn't hit the circular dependency described in #52
+  - Status transitions are accurate per the import code's `sltsLocked` check
+
+  **Verification:**
+  - A developer could follow the guide end-to-end without hitting undocumented failures
+
+- [ ] **Unit 3: Document project lifecycle workflow**
+
+  **Goal:** Step-by-step guide for creating a project with full chain + DB consistency
+
+  **Requirements:** R3
+
+  **Dependencies:** Unit 1
+
+  **Files:**
+  - Create: `docs/PROJECT-LIFECYCLE.md`
+
+  **Approach:**
+  - Document: create project on-chain → create/import tasks → assign contributors → manage commitments → assessments
+  - Show exact CLI commands at each step
+  - Simpler than courses (no SLT hash complication) but same TX lifecycle
+  - Document task hash computation and verification
+  - Cross-reference TX-LIFECYCLE.md
+
+  **Patterns to follow:**
+  - Same structure as COURSE-LIFECYCLE.md for consistency
+  - Project command reference in CLAUDE.md
+
+  **Test scenarios:**
+  - Every CLI command in the guide is real and correct
+  - Task create → export → import round-trip works with the documented flow
+
+  **Verification:**
+  - A developer could follow the guide for project creation without undocumented failures
+
+- [ ] **Unit 4: Add SLT hash computation to `course import`**
+
+  **Goal:** Import computes the SLT hash and includes it in the update payload so the natural import→mint→sync workflow works
+
+  **Requirements:** R5
+
+  **Dependencies:** None (independent of docs units)
+
+  **Files:**
+  - Modify: `cmd/andamio/course_import.go`
+  - Test: `cmd/andamio/course_import_test.go`
+
+  **Approach:**
+  - After parsing SLTs from `outline.md`, call `cardano.ComputeSltHash(sltTexts)` to get the hash
+  - Include `slt_hash` in the update payload alongside `slts` (only when `!sltsLocked`, same guard as SLTs)
+  - Log the computed hash to stderr: `"Computed SLT hash: %s\n"`
+  - Include `slt_hash` in the `ImportResult` struct for `--output json`
+  - If the API rejects `slt_hash` on the update endpoint, fall back to displaying it as a hint for manual `register-module` use
+
+  **Patterns to follow:**
+  - `course credential compute-hash` already calls `ComputeSltHash` — follow its SLT extraction pattern
+  - `internal/cardano/slt_hash.go` for the hash function
+  - Import's existing `sltsLocked` guard for conditional inclusion
+
+  **Test scenarios:**
+  - Import of a module with 3 SLTs produces the same hash as `course credential compute-hash` for the same SLTs
+  - Import with `--output json` includes `slt_hash` in the result
+  - Import of a non-DRAFT module does NOT attempt to set `slt_hash`
+  - Import with `--dry-run` shows the computed hash without sending it
+
+  **Verification:**
+  - `andamio course import <course-id> <dir> --output json | jq .slt_hash` returns a valid hex hash
+  - Hash matches `andamio course credential compute-hash --slt "..." --slt "..."`
+
+- [ ] **Unit 5: Improve `tx run` error messages for DB sync failures**
+
+  **Goal:** When `tx run` returns the `"failed"` state, provide actionable recovery guidance
+
+  **Requirements:** R6
+
+  **Dependencies:** None
+
+  **Files:**
+  - Modify: `cmd/andamio/tx_run.go`
+
+  **Approach:**
+  - In `pollTxStatus`, the `"failed"` case (line 238-239) currently returns a bare error
+  - Enhance the error to include: tx_hash, tx_type, and a hint
+  - The hint should suggest: `andamio tx status <hash>` to check current state, and `andamio tx register --tx-hash <hash> --tx-type <type>` to retry registration
+  - Format: multi-line stderr message before returning the error (gated on `!isJSON`)
+  - For JSON mode, include the hint in `RunResult.Error` field
+  - Mirror the pattern already used for register-failure recovery at lines 175-179
+
+  **Patterns to follow:**
+  - Register-failure recovery message at `tx_lifecycle.go` lines 175-179
+  - `SIGINT` handler at `tx_run.go` lines 76-88 which suggests `andamio tx status`
+
+  **Test scenarios:**
+  - `"failed"` state error message includes tx_hash and tx_type
+  - `"failed"` state in JSON mode includes recovery hint in error field
+  - Error message is actionable (contains valid CLI commands)
+
+  **Verification:**
+  - `tx run` with `--output json` on a DB-failure produces a `RunResult` with populated `tx_hash`, `state: "failed"`, and `error` containing recovery commands
+
+- [ ] **Unit 6: Update CLAUDE.md and cross-references**
+
+  **Goal:** Link the new docs from CLAUDE.md and ensure discoverability
+
+  **Requirements:** R7
+
+  **Dependencies:** Units 1-3
+
+  **Files:**
+  - Modify: `CLAUDE.md`
+
+  **Approach:**
+  - Add entries to the "Key Documentation" or a new "Workflow Guides" section in CLAUDE.md
+  - Link TX-LIFECYCLE.md, COURSE-LIFECYCLE.md, PROJECT-LIFECYCLE.md
+  - Update the "Planned Features" or relevant sections to reference the new import hash behavior
+
+  **Patterns to follow:**
+  - Existing CLAUDE.md structure and formatting
+
+  **Test scenarios:**
+  - All links are valid relative paths
+  - No broken references
+
+  **Verification:**
+  - `CLAUDE.md` references all three new docs
+
+## System-Wide Impact
+
+- **Interaction graph:** The SLT hash computation in import (Unit 4) adds a dependency on `internal/cardano/slt_hash.go` from `course_import.go`. This is a clean dependency — the hash package is already used by `course_credential.go`.
+- **Error propagation:** The improved error messages (Unit 5) don't change error types or exit codes — they enrich the message content. `RunResult.State` remains `"failed"` with exit code 1.
+- **API surface parity:** The `slt_hash` field in `ImportResult` is additive (new JSON field, non-breaking). The `slt_hash` in the update payload is a server-side concern — if the API ignores it, no harm done.
+- **Integration coverage:** The SLT hash computation should produce the same hash as `course credential compute-hash` for the same inputs. This is testable with golden values.
+
+## Risks & Dependencies
+
+- **API acceptance of `slt_hash` on update endpoint**: The `course-module/update` endpoint may not accept `slt_hash`. If so, Unit 4 falls back to displaying the hash for manual use via `register-module`. Low risk — the field is likely silently ignored if unsupported.
+- **Documentation accuracy**: The lifecycle guides describe the intended workflow, but some steps depend on API behavior that the CLI doesn't control (e.g., batch confirm matching by hash). Mitigated by cross-referencing the gateway's TX_LIFECYCLE_REFERENCE.md.
+
+## Sources & References
+
+- Related issue: #52
+- Related PR: #51 (compute-hash commands, recently merged)
+- CLI TX state machine pattern: `docs/solutions/architecture/cli-tx-state-machine-pattern-and-task-hash-verification.md`
+- PBL retro fixes: `docs/solutions/developer-experience/cli-midnight-pbl-retro-fixes.md`
+- API TX lifecycle reference: `andamio-api/docs/TX_LIFECYCLE_REFERENCE.md`
+- API task hash self-healing: `andamio-api/docs/solutions/architecture-patterns/task-hash-self-healing-wholesale-reconciliation.md`
+- API abandoned TX recovery: `andamio-api/docs/solutions/architecture-patterns/abandoned-tx-recovery-in-reconcilers.md`


### PR DESCRIPTION
## Summary

- Add three developer reference docs covering the TX lifecycle (5-step pipeline, terminal states, recovery procedures), course lifecycle (creation through publishing with SLT hash workflow), and project lifecycle (tasks, contributors, assessments)
- Compute SLT hash during `course import` so the natural import→mint→sync workflow produces matching hashes for DB sync
- Improve `tx run` error messages when DB update fails to include actionable recovery commands

## Changes

### Documentation (3 new files)
- `docs/TX-LIFECYCLE.md` — 5-step pipeline, state machine, recovery procedures, all 17 TX types
- `docs/COURSE-LIFECYCLE.md` — Step-by-step course creation through module publishing with SLT hash workflow
- `docs/PROJECT-LIFECYCLE.md` — Project creation, task management, contributor workflow, assessments

### Code improvements
- `cmd/andamio/course_import.go` — Computes SLT hash via `ComputeSltHash()` during import, includes in API payload and `ImportResult` JSON output
- `cmd/andamio/tx_lifecycle.go` — When DB update fails, prints recovery guidance (diagnostics command + re-register hint)
- `cmd/andamio/tx_run.go` — Self-contained error message for the `failed` terminal state

### Cross-references
- `CLAUDE.md` — New "Workflow Guides" section linking all 3 docs

## Test plan

- [x] `go build ./cmd/andamio/` passes
- [x] `go test ./...` passes (all existing tests)
- [ ] Verify `course import` outputs `slt_hash` in `--output json` mode
- [ ] Verify `tx run` prints recovery commands when polling returns `failed` state
- [ ] Review lifecycle docs for command accuracy against current CLI

Closes #52

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>