### PR TITLE
refactor(apierr): typed ConflictError for HTTP 409

### DIFF
--- a/.context/compound-engineering/ce-review/2026-04-22-pr68-conflict-error/findings.md
+++ b/.context/compound-engineering/ce-review/2026-04-22-pr68-conflict-error/findings.md
@@ -1,0 +1,75 @@
+---
+run_id: 2026-04-22-pr68-conflict-error
+mode: autofix
+pr: 68
+base: c986f6c8fcc711f1972019badf6f8bd915aab783
+plan: docs/plans/2026-04-22-001-refactor-typed-conflict-error-plan.md
+reviewers: correctness, testing, maintainability, project-standards, agent-native, learnings-researcher, reliability
+---
+
+# ce:review autofix run — PR #68 (typed ConflictError)
+
+## Intent
+
+Add `apierr.ConflictError` for HTTP 409. Surface from `client.Get/Post/Put`. Migrate `isModuleAlreadyExistsError` from pure string matching to three-gate check (type + `already exists` stem + `course_module_code` field). Closes #64.
+
+## Verdict
+
+**Ready with follow-up.** No blocking findings. Three `safe_auto` fixes applied; one `gated_auto` residual captured as a todo.
+
+## Applied safe_auto fixes
+
+| # | File | Fix | Reviewer |
+|---|------|-----|----------|
+| 1 | `internal/apierr/errors.go` | Trimmed `ConflictError` doc comment — removed the "Callers use `errors.As`..." sentence that explained standard Go idiom. Now matches the terseness of sibling `NotFoundError`/`AuthError` docs. | maintainability |
+| 2 | `cmd/andamio/course_teacher_ops.go` | Trimmed the `isModuleAlreadyExistsError` doc comment — removed the trailing two-sentence refactor-history narration ("The type gate replaces what the body match was silently doing..."). Kept the enumerated three-gate rationale (which carries the WHY). | maintainability |
+| 3 | `internal/client/client_test.go` | Added `strings.Contains(err.Message, "403")` and `strings.Contains(err.Message, "404")` assertions to the 403 and 404 subtests to mirror the 401/409 pattern. Catches future regressions where the message string drops the status-code prefix. | testing |
+
+All three are non-behavioral; `go test ./...` stays green, `go vet ./...` clean, `go build ./...` clean.
+
+## Residual actionable (gated_auto → downstream-resolver)
+
+### [P2] Status-only type gate can silently regress idempotency if the gateway ever returns non-409 for duplicate module_code
+
+**File:** `cmd/andamio/course_teacher_ops.go:305-310`
+
+**Cross-reviewer consensus:** reliability (P2, 0.82) + correctness residual (0.65) + project-standards residual (0.70). Merged confidence 0.92.
+
+**Why it matters:** The new three-gate predicate ANDs `errors.As(*apierr.ConflictError)` with the two body substrings. Before this PR, the predicate matched body text alone regardless of status code. If preprod or mainnet ever returns 400/422/500 for a duplicate `course_module_code` POST (wording drift, proxy rewrite, validation path firing before the conflict check), the recovery branch is skipped and callers see `"failed to register module: ..."` on what used to be an idempotent no-op. The plan's Risks & Dependencies table acknowledges this but defers the mitigation.
+
+**Fix options (concrete):**
+- **Option A (verification):** Capture a real preprod 409 response body for a duplicate `register-module` POST. Commit the body (or a sanitized fragment) as a test fixture, or document it in `docs/COURSE-LIFECYCLE.md`. One-shot curl session. Non-behavioral.
+- **Option B (belt-and-braces fallback):** In `isModuleAlreadyExistsError`, if `errors.As` fails but the raw `err.Error()` contains both body tokens, emit a warning to stderr and still return `true`. Preserves pre-PR-#68 idempotency across status-code drift at the cost of potential false positives on pathological 5xx bodies. Behavioral change — requires user sign-off.
+
+**Why gated_auto, not safe_auto:** Option B changes predicate behavior (widens beyond what the plan chose). Option A requires a human action (preprod request). Neither is mechanical.
+
+**Owner:** downstream-resolver (human follow-up on a future CLI session or a separate issue).
+
+## Advisory (human)
+
+### [P3] Document the three-gate pattern in `docs/solutions/architecture/`
+
+**Source:** learnings-researcher
+
+**Why:** The approach extends Prevention Strategy #2 from `docs/solutions/feature-implementations/cli-course-module-management-commands.md` ("sentinel errors, not string matching"), but the specific three-gate idiom (typed error + two body substrings when status alone is ambiguous) is new institutional pattern worth capturing. A short ~40-line doc under `docs/solutions/architecture/typed-error-three-gate-conflict-detection.md` cross-linked from the three existing solution docs would close the knowledge loop.
+
+**Owner:** human (judgment call — optional documentation work, not required for merge).
+
+## Not flagged (below threshold or out of scope)
+
+- `TestClient_200OK_DecodesBody` doesn't cover the `result == nil` path in Post/Put — pre-existing contract, not this PR's regression target.
+- `lookupTeacherModule` has no pagination handling — pre-existing from PR #63; confidence 0.55 below the 0.60 gate; would silently miss modules on very large courses if the gateway ever paginates.
+- `isModuleAlreadyExistsError` test table has 5 type-gate negatives where 2 would suffice — mild over-testing; reviewer explicitly noted "not worth blocking the PR over."
+- The 3× duplicated `switch resp.StatusCode` block in `client.go` — plan explicitly defers with a "5th-case trigger" threshold; all reviewers endorsed the deferral.
+
+## Requirements completeness (plan: explicit)
+
+| # | Requirement | Status |
+|---|---|---|
+| R1 | `apierr.ConflictError` exists with `Message`/`Error()` mirroring `NotFoundError`/`AuthError`, scoped HTTP-derived | met — `internal/apierr/errors.go:15-18` |
+| R2 | `client.Get`/`Post`/`Put` return `*apierr.ConflictError` for 409 | met — `client_test.go:TestClient_StatusCodeToTypedError` covers all 3 methods |
+| R3 | `isModuleAlreadyExistsError` uses `errors.As(err, &conflict)` with narrowing body check | met — `cmd/andamio/course_teacher_ops.go:301-311` |
+| R4 | Existing `TestRegisterOrRecoverModule` continues to pass without modification | met — verified end-to-end (httptest 409 → real client → typed error → recovery flow) |
+| R5 | `TestIsModuleAlreadyExistsError` updated to feed `*apierr.ConflictError` directly | met — 14 cases with isolated gate-negative coverage |
+
+All 5 met. All 3 implementation units checked off in the plan.

--- a/cmd/andamio/course_teacher_ops.go
+++ b/cmd/andamio/course_teacher_ops.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 
+	"github.com/Andamio-Platform/andamio-cli/internal/apierr"
 	"github.com/Andamio-Platform/andamio-cli/internal/client"
 	"github.com/Andamio-Platform/andamio-cli/internal/config"
 	"github.com/Andamio-Platform/andamio-cli/internal/output"
@@ -288,21 +290,23 @@ func postRegisterModule(c *client.Client, courseID, moduleCode, sltHash string) 
 }
 
 // isModuleAlreadyExistsError reports whether err looks like a duplicate course-module
-// conflict from the gateway. Requires both an "already exists" stem AND the specific
-// "course_module_code" token, so unrelated conflicts (duplicate teacher, duplicate
-// credential, "asset module already exists", "module github.com/...: already exists"
-// in proxied 5xx bodies) do not route into the module-lookup recovery branch.
+// conflict from the gateway. Three gates, ANDed together:
+//   - errors.As against *apierr.ConflictError gates on HTTP 409 (surfaced by internal/client)
+//   - "already exists" body substring gates on conflict semantics (vs e.g. 409 validation)
+//   - "course_module_code" body substring gates on the specific field (vs other 409s like
+//     duplicate teacher, duplicate credential, etc.)
 //
-// This is intentionally string-matching. The longer-term fix is a typed ConflictError
-// in internal/client (which would expose the HTTP 409 status distinct from the body).
-// Until then: the double-token predicate narrows the match enough that gateway wording
-// drift is the failure mode, not cross-command false positives. If the gateway ever
-// reworks its 409 body, update this predicate and the test cases in TestIsModuleAlreadyExistsError.
+// The type gate replaces what the body match was silently doing as a status-code proxy.
+// The body checks narrow WHICH 409 this is, which the type gate alone can't do.
 func isModuleAlreadyExistsError(err error) bool {
 	if err == nil {
 		return false
 	}
-	msg := strings.ToLower(err.Error())
+	var conflict *apierr.ConflictError
+	if !errors.As(err, &conflict) {
+		return false
+	}
+	msg := strings.ToLower(conflict.Message)
 	return strings.Contains(msg, "already exists") && strings.Contains(msg, "course_module_code")
 }
 

--- a/cmd/andamio/course_teacher_ops.go
+++ b/cmd/andamio/course_teacher_ops.go
@@ -295,9 +295,6 @@ func postRegisterModule(c *client.Client, courseID, moduleCode, sltHash string) 
 //   - "already exists" body substring gates on conflict semantics (vs e.g. 409 validation)
 //   - "course_module_code" body substring gates on the specific field (vs other 409s like
 //     duplicate teacher, duplicate credential, etc.)
-//
-// The type gate replaces what the body match was silently doing as a status-code proxy.
-// The body checks narrow WHICH 409 this is, which the type gate alone can't do.
 func isModuleAlreadyExistsError(err error) bool {
 	if err == nil {
 		return false

--- a/cmd/andamio/course_teacher_ops_test.go
+++ b/cmd/andamio/course_teacher_ops_test.go
@@ -3,30 +3,50 @@ package main
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/Andamio-Platform/andamio-cli/internal/apierr"
 	"github.com/Andamio-Platform/andamio-cli/internal/client"
 	"github.com/Andamio-Platform/andamio-cli/internal/config"
 )
 
 func TestIsModuleAlreadyExistsError(t *testing.T) {
+	// Three gates: errors.As(*apierr.ConflictError) + "already exists" + "course_module_code".
+	// The type gate blocks non-409 errors; body checks narrow WHICH 409.
+	conflict := func(body string) error { return &apierr.ConflictError{Message: body} }
+
 	tests := []struct {
 		name string
 		err  error
 		want bool
 	}{
+		// Happy paths — type + stem + field all satisfied.
+		{"ConflictError with 'already exists' and course_module_code", conflict("API error 409: course_module_code already exists in this course"), true},
+		{"ConflictError case-insensitive (mixed case body)", conflict("Course_Module_Code Already Exists"), true},
+
+		// Stem gate negatives — type passes, field passes, but no "already exists".
+		{"ConflictError mentioning course_module_code but no 'already exists' stem (validation 409)", conflict("course_module_code is invalid"), false},
+		{"ConflictError 'course_module_code must be numeric' (different stem)", conflict("course_module_code must be numeric"), false},
+
+		// Field gate negatives — type passes, stem passes, but no course_module_code.
+		{"ConflictError 'module already exists' without course_module_code token", conflict("API error 409: module already exists"), false},
+		{"ConflictError 'asset module already exists' adjacent wording", conflict("API error 409: asset module already exists"), false},
+		{"ConflictError 'teacher already exists' (different resource)", conflict("API error 409: teacher already exists"), false},
+
+		// Type gate negatives — not a ConflictError, regardless of body.
 		{"nil", nil, false},
-		{"unrelated error", errors.New("boom"), false},
-		{"already exists with course_module_code", errors.New("API error 409: course_module_code already exists in this course"), true},
-		{"case insensitive", errors.New("Course_Module_Code Already Exists"), true},
-		{"already exists with bare 'module' token (no course_module_code) is NOT a course-module conflict", errors.New("API error 409: module already exists"), false},
-		{"already exists in proxied 5xx body mentioning 'module' is NOT a course-module conflict", errors.New("API error 500: internal error in module github.com/foo: record already exists"), false},
-		{"already exists with adjacent 'asset module' wording", errors.New("API error 409: asset module already exists"), false},
-		{"already exists without module context (e.g. duplicate teacher)", errors.New("API error 409: teacher already exists"), false},
-		{"different stem (not a duplicate)", errors.New("course_module_code is invalid"), false},
+		{"plain errors.New unrelated", errors.New("boom"), false},
+		{"plain errors.New whose body contains both tokens (non-typed)", errors.New("course_module_code already exists"), false},
+		{"proxied 5xx body mentioning tokens (not a ConflictError)", errors.New("API error 500: internal error: course_module_code already exists somewhere"), false},
+		{"NotFoundError (wrong type, 404)", &apierr.NotFoundError{Message: "course_module_code already exists"}, false},
+		{"AuthError (wrong type, 401/403)", &apierr.AuthError{Message: "course_module_code already exists"}, false},
+
+		// Wrap-chain — errors.As walks through fmt.Errorf(%w).
+		{"wrapped ConflictError (via fmt.Errorf %w)", fmt.Errorf("register failed: %w", conflict("API error 409: course_module_code already exists")), true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/docs/plans/2026-04-22-001-refactor-typed-conflict-error-plan.md
+++ b/docs/plans/2026-04-22-001-refactor-typed-conflict-error-plan.md
@@ -1,0 +1,252 @@
+---
+title: "refactor: typed ConflictError for HTTP 409 in internal/client"
+type: refactor
+status: completed
+date: 2026-04-22
+deepened: 2026-04-22
+origin: https://github.com/Andamio-Platform/andamio-cli/issues/64
+---
+
+# refactor: typed ConflictError for HTTP 409 in internal/client
+
+## Overview
+
+Add `apierr.ConflictError` alongside the existing `NotFoundError`/`AuthError` types, surface it from `client.Get`/`Post`/`Put` for HTTP 409 responses, and migrate the sole caller (`isModuleAlreadyExistsError` in `course_teacher_ops.go`) to `errors.As` + a narrowing check on the error body. Close out the "string matching on gateway error bodies" anti-pattern that `docs/solutions/feature-implementations/cli-course-module-management-commands.md` explicitly warned against and that PR #63 re-introduced as acknowledged tech debt.
+
+## Problem Frame
+
+`internal/client/client.go` currently types only 401/403 (`AuthError`) and 404 (`NotFoundError`). All other non-2xx responses collapse into `errors.New("API error <code>: <body>")`. PR #63 (register-module idempotency) needed to detect 409 conflicts and resorted to `strings.Contains(msg, "already exists") && strings.Contains(msg, "course_module_code")` — documented in the code with `// TODO: Replace with a typed ConflictError in internal/client once that refactor lands.`
+
+Two problems:
+
+1. The string-match predicate is fragile to gateway wording drift (i18n, typed errors, proxy rewraps). A reworded 409 body silently drops register-module's idempotency guarantee.
+2. Every future command that needs to handle a 409 will re-invent its own substring predicate — the exact recurrence pattern that `errModuleNotFound` was introduced to prevent for 404s.
+
+The fix is small, localized, and unblocks the TODO in register-module. See issue #64 for the full framing.
+
+## Requirements Trace
+
+- **R1.** `apierr.ConflictError` type exists in `internal/apierr/errors.go` with a `Message` field and `Error()` method, mirroring the shape of `NotFoundError`/`AuthError`. Scope: HTTP-derived (surfaced by `internal/client` for 409 responses); not constructed by handlers in this PR.
+- **R2.** `client.Get`, `client.Post`, and `client.Put` return `*apierr.ConflictError` (pointer) for HTTP 409 responses, preserving the truncated body in `Message` as today.
+- **R3.** `isModuleAlreadyExistsError` in `cmd/andamio/course_teacher_ops.go` uses `errors.As(err, &conflict)` — where `var conflict *apierr.ConflictError` — as the primary signal, with a narrowing body-substring check only to disambiguate "course_module_code conflict" from other 409 kinds.
+- **R4.** Existing end-to-end tests in `cmd/andamio/course_teacher_ops_test.go` that drive 409 through `httptest` continue to pass without modification (they exercise the real client, which now produces the typed error).
+- **R5.** `TestIsModuleAlreadyExistsError` is updated to feed `*apierr.ConflictError` values directly, not synthetic `errors.New(...)` strings — so the matcher's contract is tested against the error type consumers will actually see.
+
+## Scope Boundaries
+
+- **Out of scope:** typed errors for 422, 429, 500, etc. The issue explicitly calls this a non-goal. Add 409 only; widen later if a concrete need emerges.
+- **Out of scope:** adding a new exit code (e.g., 4 for conflict) in `main.go`. Existing conflict errors exit 1 today; keeping them at 1 avoids an incidental behavior change for scripts. Recorded as a deferred question.
+- **Out of scope:** refactoring the 3× duplicated `switch resp.StatusCode` block in `client.go` into a shared helper. The duplication is bounded, and DRYing it up is a separate cleanup.
+- **Out of scope:** widening `apierr` to cover domain-level "conflict" errors constructed by handlers (analogous to how `NotFoundError` is used in `course.go` for handler-constructed not-found cases). `ConflictError` in this PR is strictly HTTP-derived.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `internal/apierr/errors.go` — three existing types (`NotFoundError`, `AuthError`, `ReportedError`) with identical shape: struct with `Message` field + pointer `Error() string` receiver. `ConflictError` should mirror this exactly.
+- `internal/client/client.go:60-69, 115-124, 162-171` — the three status-switch blocks. Duplicated in `Get`, `Post`, `Put`. Each returns `&apierr.AuthError{...}` for 401/403 and `&apierr.NotFoundError{...}` for 404 before falling through to `errors.New(msg)`.
+- `cmd/andamio/main.go:47-73` — the exit-code mapping. `errors.As(err, &notFound)` → exit 2; `errors.As(err, &authErr)` → exit 3. Walks the wrap chain, so wrapped errors still route correctly.
+- `cmd/andamio/course_teacher_ops.go` — `isModuleAlreadyExistsError` (currently ~line 301-307 including doc comment). The function to migrate. Currently a pure string match; the narrowing body check stays (filters "course_module_code" conflicts from other future 409 sources) but is layered on top of `errors.As` rather than being the primary signal.
+- `cmd/andamio/course_teacher_ops_test.go:TestIsModuleAlreadyExistsError` — the unit test table that feeds synthetic `errors.New` values. This needs updating; the other 409-driving tests in `TestRegisterOrRecoverModule` run through the real `client.Post` and need no change.
+- `internal/client/` currently has no `*_test.go` file. This plan adds `client_test.go` to lock the status-code → error-type contract so future refactors of the switch block can't silently break the mapping.
+
+### Institutional Learnings
+
+- `docs/solutions/feature-implementations/cli-course-module-management-commands.md` — Prevention Strategy #2: *"Define typed errors for distinct failure classes. Callers should use `errors.Is()` to decide behavior, **not string matching**."* Cites the `errModuleNotFound` sentinel as prior precedent for the very pattern this PR extends. This refactor is the direct application of that lesson to 409.
+- PR #63 review (ce:review output on main) flagged `isModuleAlreadyExistsError` as P1 #1 — the specific finding that motivated filing #64.
+- `docs/plans/2026-04-13-001-fix-draft-to-approved-path-plan.md` — Decision 1 from the PR #63 plan: *"Detect conflict via error-body string match, not a typed error. ... A typed `ConflictError` would be cleaner long-term, but introducing it across all three Post sites is broader than this fix needs. Rationale: scope discipline."* That scope discipline parked the work. This plan unparks it.
+
+### External References
+
+None warranted. The refactor is repo-local and follows an established local pattern. Go's `errors.As`/`errors.Is` semantics are unambiguous.
+
+## Key Technical Decisions
+
+- **Mirror the existing `NotFoundError`/`AuthError` shape.** Pointer receiver on `Error()`, struct with `Message string`, `func (e *ConflictError) Error() string { return e.Message }`, and the client returns `&apierr.ConflictError{Message: msg}` (pointer value) from the switch. Callers use `var conflict *apierr.ConflictError; errors.As(err, &conflict)` — the pointer-receiver/pointer-return symmetry is load-bearing; a value-receiver would break `errors.As` matching. Rationale: consistency with the three existing types means zero surprise for reviewers and no divergence in how `main.go`'s `errors.As` chain works.
+- **Add the 409 case to all three client methods (`Get`/`Post`/`Put`).** Do not gate on "only Post hits 409 today." Rationale: the contract is about status codes, not about which methods happen to encounter them in current callers. A future GET endpoint that 409s would otherwise be inconsistent.
+- **Keep the narrowing body check in `isModuleAlreadyExistsError`.** `errors.As` answers "is this a 409?"; the body substring ("course_module_code") answers "is this the specific 409 register-module cares about, not a future duplicate-teacher / duplicate-credential conflict?" Rationale: a 409 on `/course-module/register` is extremely likely to be a module-code conflict, but the CLI cannot assume 1:1 mapping between endpoint and conflict class as the API surface grows.
+- **Do not add a new exit code for conflict.** Stay at exit 1. Rationale: expanding the exit-code contract is a separate product decision (and a script-visible behavior change for error paths that previously happened to exit 1). Deferred to `Open Questions`.
+- **Lock the status → type mapping with a new `internal/client/client_test.go`.** First test file for the package. Covers 401/403/404/409 (regression for the existing typed errors + new coverage for 409) plus a generic 500 to verify fall-through. Rationale: the handler-layer tests will catch most breakage, but pinning the mapping at the client layer protects against a future switch-block refactor silently dropping a case.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should `ConflictError` preserve the raw body or parse structured fields?** Preserve as-is (just the truncated body in `Message`). Same shape as `NotFoundError`/`AuthError`; callers that need structured details continue to inspect the body substring. Revisit only if a caller needs programmatic access to a gateway error-code field.
+- **Should the status-switch in `client.go` be DRYed up as part of this PR?** No — see scope boundaries. The duplication is bounded (3× identical switch), and factoring it out is a drive-by cleanup that would inflate the diff and delay the load-bearing fix.
+- **Does the mismatch-error-wrapping chain in `register-module` still unwrap correctly after the type change?** Yes. `mismatchError` wraps the original `error` via `%w`. When the wrapped error is now `*apierr.ConflictError`, `errors.As(wrapped, &conflict)` still succeeds through the chain. Existing `TestMismatchError` already asserts `errors.Is(err, gateway)` — the test will keep passing.
+
+### Deferred to Implementation
+
+- **Whether to simplify the narrowing predicate by dropping the `"already exists"` stem.** The plan keeps all three gates (`errors.As` + `"already exists"` + `"course_module_code"`) for safety. Dropping the stem could make `"course_module_code is invalid"` (a hypothetical validation-409) route into the recovery branch, which would surface a confusing "module not found in teacher list" error instead of the gateway's accurate validation message. Reconsider only after capturing real preprod 409 bodies for both duplicate-registration and validation error paths; if the gateway consistently distinguishes them by status code (409 for duplicate, 4xx for validation), the stem becomes redundant and can be dropped in a follow-up.
+- **Whether to add a dedicated exit code for conflict.** Not in this PR. `register-module` internalizes conflicts into its recovery/mismatch flow, so no exit code is needed for the current consumer. Revisit only when a command ships that wants to surface conflict to the caller WITHOUT internal recovery — e.g., a future command that wants "this module is referenced elsewhere" as a user-actionable exit code distinct from generic failure.
+- **When to extract the duplicated `switch resp.StatusCode` block in `client.go` into a helper.** Not this PR — bounded at 4 cases × 3 methods (see scope boundaries). Trigger for the extraction: the next typed error added (the 5th case in each switch). Three duplicated 5-case switches is the tipping point; two 4-case switches is still fine.
+
+## Implementation Units
+
+```mermaid
+flowchart TB
+  U1[Unit 1: Add ConflictError type<br/>internal/apierr/errors.go]
+  U2[Unit 2: Surface 409 from client<br/>internal/client/client.go + client_test.go]
+  U3[Unit 3: Migrate isModuleAlreadyExistsError<br/>course_teacher_ops.go + test updates]
+  U1 --> U2
+  U2 --> U3
+```
+
+- [x] **Unit 1: Add `ConflictError` type**
+
+**Goal:** Introduce the new typed error in `internal/apierr` with the same shape as the existing types.
+
+**Requirements:** R1
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `internal/apierr/errors.go`
+- Test: none — mirror of existing types; no per-type logic to test. Test coverage lands in Unit 2 at the client layer.
+
+**Approach:**
+- Add a `ConflictError` struct with `Message string` and a pointer receiver `Error() string` method.
+- Place it after `AuthError` and before `ReportedError` in the file so HTTP-derived types stay grouped.
+- Include a short doc comment referencing HTTP 409 and noting it is surfaced by `internal/client`. Do NOT add an exit-code-mapping comment (like `NotFoundError`'s "main.go maps this to exit code 2") — no new exit code is being added in this PR.
+
+**Patterns to follow:**
+- `internal/apierr/errors.go` lines 3-13 (`NotFoundError`, `AuthError`). Same shape, same receiver style, same comment format minus the exit-code line.
+
+**Test scenarios:** Test expectation: none — pure type declaration, no behavior to test at the apierr layer. Behavior is verified at the client layer in Unit 2.
+
+**Verification:**
+- `go build ./...` is clean.
+- `grep -n ConflictError internal/apierr/errors.go` shows the new type.
+
+- [x] **Unit 2: Surface 409 from `internal/client`**
+
+**Goal:** Add the 409 case to the three status-code switches in `client.go` so HTTP 409 responses return `*apierr.ConflictError`. Add first tests for the package to lock the mapping.
+
+**Requirements:** R2
+
+**Dependencies:** Unit 1.
+
+**Files:**
+- Modify: `internal/client/client.go`
+- Create: `internal/client/client_test.go`
+
+**Approach:**
+- In each of the three switch blocks (`Get` method ~line 60-69, `Post` method ~line 115-124, `Put` method ~line 162-171), add `case http.StatusConflict: return &apierr.ConflictError{Message: msg}` **after** the existing 404 case so the full sequence is 401/403 → 404 → 409 in numeric order. The test table in `client_test.go` should mirror this same 401, 403, 404, 409, 500 ordering.
+- Leave the fall-through `errors.New(msg)` for all other non-2xx responses unchanged.
+- `client_test.go`: table-driven test against an `httptest.Server` that returns a parametrized status + body. For each of `Get`, `Post`, `Put`: assert the returned error type matches expectations for 401/403/404/409/500.
+- Use `errors.As` for assertions (the same mechanism callers will use). This pins the contract at the consumer's POV, not the constructor's.
+
+**Patterns to follow:**
+- `cmd/andamio/course_teacher_ops_test.go` for httptest harness style (already exists in the codebase; mirrors its setup for consistency).
+- Existing switch statements in `client.go` lines 60-69, 115-124, 162-171 — drop the new case in the same shape.
+
+**Test scenarios:**
+- Happy path: Client receives 200 OK → returns nil error and decodes body into result. One test covering `Get`, `Post`, `Put` each.
+- Error path — 401: Client receives 401 → returns `*apierr.AuthError` (regression — locks existing behavior against a future switch-block refactor).
+- Error path — 403: Client receives 403 → returns `*apierr.AuthError` (regression).
+- Error path — 404: Client receives 404 → returns `*apierr.NotFoundError` (regression).
+- Error path — 409: Client receives 409 with body `"course_module_code already exists in this course"` → returns `*apierr.ConflictError` whose `Message` contains both the status code and the body.
+- Error path — 500: Client receives 500 → returns a non-typed `error` (i.e., `errors.As` fails to match any of the three typed errors). Locks the fall-through.
+- Integration: For each typed error case, run `errors.As` through an additional `fmt.Errorf("wrapped: %w", err)` to prove the wrap chain still unwraps correctly. This mirrors how `mismatchError` wraps in `course_teacher_ops.go`.
+- Edge case: 409 with an empty body → still returns `*apierr.ConflictError` (don't special-case empty bodies; the type is determined by status alone).
+
+**Verification:**
+- `go test ./internal/client/...` passes.
+- `go test ./...` stays green (the integration path through `cmd/andamio/course_teacher_ops_test.go` now exercises the typed error without code changes to those tests).
+- `grep ConflictError internal/client/client.go` shows three occurrences (one per method).
+
+- [x] **Unit 3: Migrate `isModuleAlreadyExistsError` to `errors.As`**
+
+**Goal:** Replace the string-match-only predicate with `errors.As(err, *apierr.ConflictError)` plus a narrowing body check for the `course_module_code` token. Remove the TODO comment that references the now-delivered refactor. Update the unit test to feed typed errors.
+
+**Requirements:** R3, R4, R5
+
+**Dependencies:** Units 1 and 2.
+
+**Files:**
+- Modify: `cmd/andamio/course_teacher_ops.go`
+- Modify: `cmd/andamio/course_teacher_ops_test.go`
+
+**Approach:**
+- Rewrite `isModuleAlreadyExistsError`:
+  - Return `false` if `err` is `nil` (existing behavior, preserve).
+  - Declare `var conflict *apierr.ConflictError` and call `errors.As(err, &conflict)` — if not a `*apierr.ConflictError`, return `false`.
+  - On the lowered `conflict.Message`, keep **both** substring checks: `strings.Contains(msg, "already exists") && strings.Contains(msg, "course_module_code")`. The type gate (`errors.As`) replaces the *implicit* HTTP-409 check that the substring predicate served as a proxy for; it does NOT replace the need to narrow *which* 409 this is. Dropping the `"already exists"` stem would flip the existing test case `"course_module_code is invalid" → false` to `true`, silently routing a validation-409 into the destructive recovery branch. Keep the stem; the refactor's win comes from the type gate, not from predicate simplification.
+- Rewrite the function doc comment:
+  - Remove the TODO line (`// TODO: Replace with a typed ConflictError...`) — it's done.
+  - Replace with a short note explaining the three-gate check: `errors.As` for the typed 409, `"already exists"` for the conflict stem, `"course_module_code"` for the field-level narrowing.
+- Update `TestIsModuleAlreadyExistsError`:
+  - Change the test table's `err` column from `error` (via `errors.New`) to pointers — most cases become `&apierr.ConflictError{Message: ...}`, a few remain as `errors.New` to verify non-ConflictError errors return `false`.
+  - Case-by-case migration:
+    - "already exists with course_module_code" — convert body string to `&apierr.ConflictError{Message: "API error 409: course_module_code already exists in this course"}` → `true`.
+    - "case insensitive" — convert to `&apierr.ConflictError{Message: ...}` with the same body → `true`.
+    - "unrelated error" — keep as `errors.New("boom")` → `false` (not a ConflictError; proves the type gate).
+    - "bare 'module' 409 is NOT a course-module conflict" — convert to `*apierr.ConflictError` with body `"API error 409: module already exists"` → stays `false` (type gate passes, narrowing token check fails).
+    - "proxied 5xx body mentioning module" — keep as plain `errors.New(...)` → `false` (type gate blocks it; 5xx is not a ConflictError regardless of body).
+    - "adjacent 'asset module' wording" — convert to `*apierr.ConflictError` → stays `false` (narrowing check still requires `course_module_code`).
+    - "duplicate teacher 409" — convert to `*apierr.ConflictError` → stays `false` (narrowing check filters non-course_module_code 409s).
+    - "different stem" — `*apierr.ConflictError{Message: "course_module_code is invalid"}` → **see Open Questions / Deferred to Implementation for this predicate decision**; the default per this plan is to **retain the `"already exists"` stem check** so this case continues to return `false`. The decision to drop the stem is deferred pending verification of real gateway 409 bodies (see Risks & Dependencies).
+- No changes needed to `TestRegisterOrRecoverModule` (still drives real httptest 409s, which now produce the typed error) or `TestMismatchError` (uses `errors.Is` on the wrap chain, unaffected by type change).
+
+**Patterns to follow:**
+- `cmd/andamio/main.go:60-72` — canonical `errors.As` + typed-error style.
+- `cmd/andamio/helpers.go:74-76` — `errors.As(err, *apierr.NotFoundError)` pattern already used in handlers.
+
+**Test scenarios:**
+- Happy path: `*apierr.ConflictError` with body `"API error 409: course_module_code already exists in this course"` → returns `true` (all three gates pass).
+- Happy path: Wrapped `*apierr.ConflictError` (via `fmt.Errorf("register failed: %w", conflict)`) → returns `true`. Proves the wrap chain is walked correctly via `errors.As`.
+- Edge case: `*apierr.ConflictError` whose body is `"course_module_code is invalid"` (type gate passes, field gate passes, but stem gate fails) → returns `false`. Locks the decision to retain the stem check — a future simplification that drops it will break this test.
+- Error path: `*apierr.ConflictError` whose body does NOT mention `course_module_code` (e.g., `"teacher already exists"` — a future distinct 409) → returns `false`. The field narrowing check fires.
+- Error path: `*apierr.ConflictError` whose body mentions `course_module_code` but not `already exists` (e.g., `"course_module_code must be numeric"`) → returns `false`. The stem narrowing check fires.
+- Error path: plain `errors.New("API error 409: course_module_code already exists")` (a non-typed error whose body happens to contain the tokens) → returns `false`. The type gate blocks false positives that the old pure-string predicate would have accepted.
+- Error path: `*apierr.NotFoundError` (404, wrong type) → returns `false`.
+- Error path: `*apierr.AuthError` (401/403, wrong type) → returns `false`.
+- Edge case: `nil` error → returns `false`. Preserves existing behavior.
+- Integration: A full run of `TestRegisterOrRecoverModule` still passes unchanged — the existing httptest-driven 409 tests (DRAFT advance, APPROVED no-op, ON_CHAIN no-op, hash mismatch, list-lookup failure, update-status failure, unexpected status) flow through the real client and exercise the typed error end-to-end without test modification.
+
+**Verification:**
+- `go test ./...` passes.
+- `grep -n 'TODO.*ConflictError' cmd/andamio/course_teacher_ops.go` returns no matches (the "once that refactor lands" TODO is satisfied).
+- `grep -n 'errors.As' cmd/andamio/course_teacher_ops.go` shows the new usage in `isModuleAlreadyExistsError`.
+- `grep -n '"already exists"' cmd/andamio/course_teacher_ops.go` continues to return a match (stem check is retained per the predicate decision above).
+- Build a binary and run `andamio course teacher register-module --help`; output is unchanged (no user-facing surface changes).
+
+## System-Wide Impact
+
+- **Interaction graph:** `client.Get`/`Post`/`Put` now return `*apierr.ConflictError` on 409. Only one call site actively branches on the type today (`isModuleAlreadyExistsError`). All other handlers that encounter a 409 see the same `Error()` string they saw before — the type is additive, so non-typed-aware call sites keep printing the message as before. `main.go` does not currently map `ConflictError` to a distinct exit code, so exit behavior for unhandled 409s is unchanged (exit 1 via the fall-through in the error switch).
+- **Error propagation:** `*apierr.ConflictError` wraps safely through `fmt.Errorf(... %w ...)` (verified in tests). `main.go`'s `errors.As` chain already walks wraps, so if a future handler wraps a conflict and a future exit-code decision maps it to code 4, the routing Just Works.
+- **State lifecycle risks:** None. This is a pure type-introduction + call-site migration. No persistent state is touched, no migrations, no runtime behavior shifts.
+- **API surface parity:** CLI command surface is unchanged. The `--output json` envelope shipped in #63 is unchanged — error responses still use the global `{"error": "..."}` shape with the same message text; the type change is internal.
+- **Integration coverage:** The existing `TestRegisterOrRecoverModule` suite drives real 409s through the client and is the primary integration guarantee that this change doesn't break the register-module idempotency guarantee from #63.
+- **Unchanged invariants:**
+  - Existing exit codes 0/1/2/3 are preserved. No new exit code is introduced in this PR.
+  - `*apierr.NotFoundError` and `*apierr.AuthError` routing is unchanged — the new 409 case is inserted between them in the switch but does not reorder or alter the existing cases.
+  - `mismatchError` wrap chain (`fmt.Errorf(... %w ...)` via PR #63) continues to preserve the original gateway error across `errors.Unwrap` — now with a typed error inside the wrap instead of a generic one, but the chain semantics are identical.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Gateway returns a non-409 status code for a module-code conflict (e.g., 400 or 422 from some future validation path). The new predicate's `errors.As` gate silently returns `false` and register-module loses its idempotency guarantee for that path. | Before merging, capture a real preprod 409 response body for a duplicate `register-module` call and commit it as a test fixture or documented evidence. If the gateway ever uses a different status, the captured body will surface the discrepancy at PR time. Follow-up: if discrepancy is real, either widen `ConflictError` to 422 or keep a body-substring fallback path. |
+| Gateway returns 409 for an unrelated kind of conflict whose body also contains both `already exists` and `course_module_code` (e.g., a future cross-module validation or policy error referencing the field name). | All three gates (`errors.As` + `"already exists"` + `"course_module_code"`) are ANDed. Even if all three fire by coincidence, the deeper defense is `lookupTeacherModule` re-checking hash + status and either no-op'ing or surfacing a lookup error — never mutating state on a wrong match. Failure mode is a confusing error message, not corruption. |
+| A future refactor of `client.go`'s triplicated switch block (e.g., factoring into a helper) drops the 409 case silently. | New `internal/client/client_test.go` pins the status → type mapping (401, 403, 404, 409, 500). Any regression is caught before merge. |
+| Someone declares the `errors.As` target as a value type (`var c apierr.ConflictError`) instead of a pointer type (`var c *apierr.ConflictError`) and ships code that compiles but silently never matches. | Unit 3's Approach section shows the explicit pointer declaration. `client_test.go` asserts `errors.As` works against `*apierr.ConflictError` specifically. Test would catch a caller using value type. |
+
+## Documentation / Operational Notes
+
+- `CLAUDE.md` command reference — no change (the CLI surface is unchanged; this is an internal refactor).
+- `docs/COURSE-LIFECYCLE.md` — no change (behavior is unchanged end-to-end; register-module still advances, no-ops, or errors the same way).
+- No release note required for `--output json` consumers. This change is invisible to script/agent consumers that parse the error envelope — the `{"error": "..."}` message string is the same.
+- No monitoring/alerting changes.
+
+## Sources & References
+
+- **Origin issue:** https://github.com/Andamio-Platform/andamio-cli/issues/64
+- **PR that introduced the tech debt:** https://github.com/Andamio-Platform/andamio-cli/pull/63
+- **Prior solution establishing the pattern:** `docs/solutions/feature-implementations/cli-course-module-management-commands.md` (Prevention Strategy #2)
+- **Prior plan referencing this as future work:** `docs/plans/2026-04-13-001-fix-draft-to-approved-path-plan.md` (Decision 1)
+- **Existing typed errors to mirror:** `internal/apierr/errors.go` (`NotFoundError`, `AuthError`)
+- **Call site to migrate:** `cmd/andamio/course_teacher_ops.go` (`isModuleAlreadyExistsError`)
+- **Client switch-block sites:** `internal/client/client.go:60-69, 115-124, 162-171`
+- **Exit-code mapping:** `cmd/andamio/main.go:47-73`

--- a/internal/apierr/errors.go
+++ b/internal/apierr/errors.go
@@ -13,8 +13,6 @@ type AuthError struct{ Message string }
 func (e *AuthError) Error() string { return e.Message }
 
 // ConflictError is returned when a request conflicts with existing state (HTTP 409).
-// Surfaced by internal/client for 409 responses. Callers use errors.As(err, &conflict)
-// where var conflict *ConflictError to branch on conflict-specific recovery flows.
 type ConflictError struct{ Message string }
 
 func (e *ConflictError) Error() string { return e.Message }

--- a/internal/apierr/errors.go
+++ b/internal/apierr/errors.go
@@ -12,6 +12,13 @@ type AuthError struct{ Message string }
 
 func (e *AuthError) Error() string { return e.Message }
 
+// ConflictError is returned when a request conflicts with existing state (HTTP 409).
+// Surfaced by internal/client for 409 responses. Callers use errors.As(err, &conflict)
+// where var conflict *ConflictError to branch on conflict-specific recovery flows.
+type ConflictError struct{ Message string }
+
+func (e *ConflictError) Error() string { return e.Message }
+
 // ReportedError wraps an error whose output has already been printed to stdout
 // (e.g., a structured JSON result). main.go should set the exit code from the
 // wrapped error but skip printing a second error message.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -65,6 +65,8 @@ func (c *Client) Get(path string, result interface{}) error {
 			return &apierr.AuthError{Message: msg}
 		case http.StatusNotFound:
 			return &apierr.NotFoundError{Message: msg}
+		case http.StatusConflict:
+			return &apierr.ConflictError{Message: msg}
 		}
 		return errors.New(msg)
 	}
@@ -120,6 +122,8 @@ func (c *Client) Post(path string, body interface{}, result interface{}) error {
 			return &apierr.AuthError{Message: msg}
 		case http.StatusNotFound:
 			return &apierr.NotFoundError{Message: msg}
+		case http.StatusConflict:
+			return &apierr.ConflictError{Message: msg}
 		}
 		return errors.New(msg)
 	}
@@ -167,6 +171,8 @@ func (c *Client) Put(path string, body interface{}, result interface{}) error {
 			return &apierr.AuthError{Message: msg}
 		case http.StatusNotFound:
 			return &apierr.NotFoundError{Message: msg}
+		case http.StatusConflict:
+			return &apierr.ConflictError{Message: msg}
 		}
 		return errors.New(msg)
 	}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -49,6 +49,9 @@ func TestClient_StatusCodeToTypedError(t *testing.T) {
 				if !errors.As(err, &authErr) {
 					t.Fatalf("want *apierr.AuthError, got %T: %v", err, err)
 				}
+				if !strings.Contains(authErr.Message, "403") {
+					t.Errorf("AuthError.Message should contain status 403, got %q", authErr.Message)
+				}
 			},
 		},
 		{
@@ -59,6 +62,9 @@ func TestClient_StatusCodeToTypedError(t *testing.T) {
 				var notFound *apierr.NotFoundError
 				if !errors.As(err, &notFound) {
 					t.Fatalf("want *apierr.NotFoundError, got %T: %v", err, err)
+				}
+				if !strings.Contains(notFound.Message, "404") {
+					t.Errorf("NotFoundError.Message should contain status 404, got %q", notFound.Message)
 				}
 			},
 		},

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1,0 +1,194 @@
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Andamio-Platform/andamio-cli/internal/apierr"
+	"github.com/Andamio-Platform/andamio-cli/internal/config"
+)
+
+// TestClient_StatusCodeToTypedError locks the contract between HTTP status codes
+// and the typed error values surfaced by Get/Post/Put. A future refactor that
+// drops a case or reorders the switch block fails here.
+func TestClient_StatusCodeToTypedError(t *testing.T) {
+	type assertFn func(t *testing.T, err error)
+
+	// Match order follows switch-block order: 401, 403, 404, 409, 500 (fall-through).
+	cases := []struct {
+		name   string
+		status int
+		body   string
+		assert assertFn
+	}{
+		{
+			name:   "401 → AuthError",
+			status: http.StatusUnauthorized,
+			body:   "unauthorized",
+			assert: func(t *testing.T, err error) {
+				var authErr *apierr.AuthError
+				if !errors.As(err, &authErr) {
+					t.Fatalf("want *apierr.AuthError, got %T: %v", err, err)
+				}
+				if !strings.Contains(authErr.Message, "401") {
+					t.Errorf("AuthError.Message should contain status 401, got %q", authErr.Message)
+				}
+			},
+		},
+		{
+			name:   "403 → AuthError",
+			status: http.StatusForbidden,
+			body:   "forbidden",
+			assert: func(t *testing.T, err error) {
+				var authErr *apierr.AuthError
+				if !errors.As(err, &authErr) {
+					t.Fatalf("want *apierr.AuthError, got %T: %v", err, err)
+				}
+			},
+		},
+		{
+			name:   "404 → NotFoundError",
+			status: http.StatusNotFound,
+			body:   "not found",
+			assert: func(t *testing.T, err error) {
+				var notFound *apierr.NotFoundError
+				if !errors.As(err, &notFound) {
+					t.Fatalf("want *apierr.NotFoundError, got %T: %v", err, err)
+				}
+			},
+		},
+		{
+			name:   "409 → ConflictError",
+			status: http.StatusConflict,
+			body:   "course_module_code already exists in this course",
+			assert: func(t *testing.T, err error) {
+				var conflict *apierr.ConflictError
+				if !errors.As(err, &conflict) {
+					t.Fatalf("want *apierr.ConflictError, got %T: %v", err, err)
+				}
+				if !strings.Contains(conflict.Message, "409") {
+					t.Errorf("ConflictError.Message should contain status 409, got %q", conflict.Message)
+				}
+				if !strings.Contains(conflict.Message, "course_module_code") {
+					t.Errorf("ConflictError.Message should preserve body, got %q", conflict.Message)
+				}
+			},
+		},
+		{
+			name:   "500 → plain error (fall-through; no typed match)",
+			status: http.StatusInternalServerError,
+			body:   "internal server error",
+			assert: func(t *testing.T, err error) {
+				var authErr *apierr.AuthError
+				var notFound *apierr.NotFoundError
+				var conflict *apierr.ConflictError
+				if errors.As(err, &authErr) || errors.As(err, &notFound) || errors.As(err, &conflict) {
+					t.Fatalf("500 must not match any typed error, got %T: %v", err, err)
+				}
+				if !strings.Contains(err.Error(), "500") {
+					t.Errorf("generic error should contain status 500, got %q", err.Error())
+				}
+			},
+		},
+	}
+
+	methods := []struct {
+		name string
+		call func(c *Client, path string) error
+	}{
+		{"Get", func(c *Client, path string) error {
+			var out map[string]interface{}
+			return c.Get(path, &out)
+		}},
+		{"Post", func(c *Client, path string) error {
+			var out map[string]interface{}
+			return c.Post(path, map[string]string{"k": "v"}, &out)
+		}},
+		{"Put", func(c *Client, path string) error {
+			var out map[string]interface{}
+			return c.Put(path, map[string]string{"k": "v"}, &out)
+		}},
+	}
+
+	for _, m := range methods {
+		for _, tc := range cases {
+			t.Run(m.name+"/"+tc.name, func(t *testing.T) {
+				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					http.Error(w, tc.body, tc.status)
+				}))
+				defer srv.Close()
+
+				c := New(&config.Config{BaseURL: srv.URL})
+				err := m.call(c, "/any/path")
+				if err == nil {
+					t.Fatalf("expected error for status %d, got nil", tc.status)
+				}
+				tc.assert(t, err)
+			})
+		}
+	}
+}
+
+// TestClient_TypedErrorsSurviveWrapChain confirms that callers wrapping typed
+// errors via fmt.Errorf(%w) can still extract them with errors.As. This is
+// the property register-module relies on for mismatchError wrapping.
+func TestClient_TypedErrorsSurviveWrapChain(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "course_module_code already exists", http.StatusConflict)
+	}))
+	defer srv.Close()
+
+	c := New(&config.Config{BaseURL: srv.URL})
+	var out map[string]interface{}
+	rawErr := c.Post("/x", map[string]string{}, &out)
+	if rawErr == nil {
+		t.Fatal("expected error")
+	}
+
+	wrapped := fmt.Errorf("register failed: %w", rawErr)
+	var conflict *apierr.ConflictError
+	if !errors.As(wrapped, &conflict) {
+		t.Fatalf("errors.As should unwrap *ConflictError through fmt.Errorf(%%w); got %T", wrapped)
+	}
+}
+
+// TestClient_200OK_DecodesBody is the single happy-path assertion for each
+// method. Not a behavioral focus of this PR but pins the non-error contract
+// alongside the error-type contract above.
+func TestClient_200OK_DecodesBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{"ok": "yes"})
+	}))
+	defer srv.Close()
+
+	c := New(&config.Config{BaseURL: srv.URL})
+
+	var got map[string]string
+	if err := c.Get("/x", &got); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got["ok"] != "yes" {
+		t.Errorf("Get decoded %v, want ok=yes", got)
+	}
+
+	got = nil
+	if err := c.Post("/x", map[string]string{"a": "b"}, &got); err != nil {
+		t.Fatalf("Post: %v", err)
+	}
+	if got["ok"] != "yes" {
+		t.Errorf("Post decoded %v, want ok=yes", got)
+	}
+
+	got = nil
+	if err := c.Put("/x", map[string]string{"a": "b"}, &got); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if got["ok"] != "yes" {
+		t.Errorf("Put decoded %v, want ok=yes", got)
+	}
+}

--- a/todos/021-pending-p2-verify-gateway-409-for-duplicate-module.md
+++ b/todos/021-pending-p2-verify-gateway-409-for-duplicate-module.md
@@ -1,0 +1,100 @@
+---
+status: pending
+priority: p2
+issue_id: "021"
+tags: [code-review, reliability, client, conflict-detection, pr-68]
+dependencies: []
+---
+
+# Verify Gateway Returns HTTP 409 for Duplicate course_module_code
+
+## Problem Statement
+
+PR #68 migrated `isModuleAlreadyExistsError` from pure string matching to a three-gate check:
+`errors.As(err, *apierr.ConflictError)` + body `"already exists"` + body `"course_module_code"`.
+
+The type gate (`errors.As`) is load-bearing — it replaces what the body-only predicate was silently doing as a status-code proxy. The gate fires only when `internal/client.Post` returns `*apierr.ConflictError`, which happens only on HTTP 409 responses.
+
+**The entire register-module idempotency guarantee now depends on the preprod/mainnet Andamio gateway actually returning status 409 (not 400, 422, or 500) when a client POSTs `/api/v2/course/teacher/course-module/register` with a duplicate `course_module_code`.**
+
+No preprod smoke test was run as part of PR #68. The unit tests mock the status. If the gateway returns a different status code (wording drift, proxy rewrite, validation path firing before the conflict check), the recovery branch silently regresses: callers see `"failed to register module: ..."` on what the old predicate treated as an idempotent no-op.
+
+Cross-reviewer consensus on this finding during ce:review of PR #68 (reliability P2 + correctness residual + project-standards residual). Documented in the plan's Risks & Dependencies table but not yet actioned.
+
+## Affected Files
+
+- `cmd/andamio/course_teacher_ops.go:301-311` — `isModuleAlreadyExistsError`
+- `internal/client/client.go:60-72, 117-129, 166-178` — typed-error surfacing
+- `docs/plans/2026-04-22-001-refactor-typed-conflict-error-plan.md` — Risks table row
+
+## Options
+
+### Option A (verification only, non-behavioral)
+
+Capture a real preprod 409 response body for a duplicate `register-module` POST. Commit the raw HTTP status + body (or a sanitized fragment) as either:
+- a test fixture under `internal/client/testdata/preprod-409-duplicate-module.txt`, OR
+- a short appendix in `docs/COURSE-LIFECYCLE.md` under the "Already exists on register-module" troubleshooting section.
+
+One-shot curl session to reproduce:
+
+```bash
+# Assume a course with module code 101 already exists in DRAFT
+andamio course teacher register-module \
+  --course-id <course-id> \
+  --module-code 101 \
+  --slt-hash <correct-matching-hash>
+# On a SECOND run with a different user that hasn't seen the module, we need to
+# capture the raw 409. Easiest is to hit the endpoint directly with curl and
+# inspect Status-Line + body.
+curl -i -X POST https://preprod.api.andamio.io/api/v2/course/teacher/course-module/register \
+  -H "Authorization: Bearer $JWT" \
+  -H "Content-Type: application/json" \
+  -d '{"course_id":"<id>","course_module_code":"101","slt_hash":"<hash>"}' \
+  | tee preprod-409-capture.txt
+```
+
+If the status line is indeed `HTTP/1.1 409 Conflict`, record it and close this todo as verified. If it's anything else (400/422/500 with a different body, or 409 with wording that doesn't contain both `"already exists"` and `"course_module_code"`), proceed to Option B.
+
+### Option B (belt-and-braces fallback, behavioral change)
+
+Widen `isModuleAlreadyExistsError` so the body-token match still fires on non-`ConflictError` errors whose body contains both tokens, with a stderr warning that the gateway wasn't recognized as returning 409:
+
+```go
+func isModuleAlreadyExistsError(err error) bool {
+    if err == nil {
+        return false
+    }
+    var conflict *apierr.ConflictError
+    if errors.As(err, &conflict) {
+        msg := strings.ToLower(conflict.Message)
+        return strings.Contains(msg, "already exists") && strings.Contains(msg, "course_module_code")
+    }
+    // Fallback: the gateway may not have surfaced 409 for this conflict. If both
+    // body tokens are present, treat as a conflict but warn the operator so the
+    // gateway wording drift can be investigated.
+    msg := strings.ToLower(err.Error())
+    if strings.Contains(msg, "already exists") && strings.Contains(msg, "course_module_code") {
+        fmt.Fprintf(os.Stderr, "warning: conflict detected via body-token fallback; gateway did not surface HTTP 409. Please report this wording/status drift.\n")
+        return true
+    }
+    return false
+}
+```
+
+Trade-off: preserves pre-PR-#68 idempotency across gateway status drift at the cost of potential false positives on pathological 5xx bodies that happen to contain both tokens.
+
+**Preferred:** Option A first. Only do Option B if Option A reveals the gateway doesn't return 409.
+
+## Acceptance
+
+- [ ] Real preprod 409 body captured and recorded (fixture file OR doc appendix).
+- [ ] If 409 is confirmed with the expected body tokens, close this todo as "verified — no code change needed."
+- [ ] If the gateway returns a different status or different wording, implement Option B (with stderr warning) and add a test case to `TestIsModuleAlreadyExistsError` covering the fallback path.
+- [ ] If Option B is implemented, update the plan's `Risks & Dependencies` table to mark the mitigation as "delivered" and update `isModuleAlreadyExistsError`'s doc comment to mention the fallback.
+
+## Context
+
+- **Plan:** `docs/plans/2026-04-22-001-refactor-typed-conflict-error-plan.md` (status: completed for the type-gate refactor itself; this todo tracks the deferred verification).
+- **ce:review run artifact:** `.context/compound-engineering/ce-review/2026-04-22-pr68-conflict-error/findings.md`
+- **Origin PR:** https://github.com/Andamio-Platform/andamio-cli/pull/68
+- **Origin issue:** https://github.com/Andamio-Platform/andamio-cli/issues/64

--- a/todos/022-pending-p3-concurrent-update-status-conflict-recovery.md
+++ b/todos/022-pending-p3-concurrent-update-status-conflict-recovery.md
@@ -1,0 +1,54 @@
+---
+status: pending
+priority: p3
+issue_id: "022"
+tags: [code-review, reliability, concurrency, register-module, pr-68-followup]
+dependencies: []
+---
+
+# Concurrent update-status 409 Not Caught in register-module Recovery
+
+## Problem Statement
+
+PR #68 migrated register-module's conflict detection to a typed-error check via `isModuleAlreadyExistsError`. That predicate catches 409s on the **initial** register POST. It does NOT catch 409s on the **follow-up** `postUpdateModuleStatus` call inside the recovery branch.
+
+Scenario: two agents race `register-module --course-id X --module-code 101 --slt-hash <h>` on the same module:
+
+1. Agent A's register POST succeeds (200) → module advanced to APPROVED → Agent A exits 0.
+2. Agent B's register POST returns 409 → recovery branch triggered.
+3. Agent B's `lookupTeacherModule` finds module in DRAFT (read happens after Agent A's 200 is committed but before the teacher-list cache refreshes) OR finds it in APPROVED.
+4. If it finds DRAFT (stale read): Agent B calls `postUpdateModuleStatus(APPROVED, sltHash)`. The gateway rejects because the module is no longer in DRAFT — likely returning 409 or a status-mismatch error.
+5. Agent B surfaces: `"module 101 exists in DRAFT with matching hash, but advancing to APPROVED failed: <gateway error>"` — a hard, non-zero exit.
+
+The desired end state (module APPROVED) has already been reached. The race loser should treat the update-status 409 as "already done" and exit 0 via the `already_registered` envelope, not fail.
+
+This pre-existed from PR #63 but became more visible post-PR-#68 because the typed-error boundary now cleanly distinguishes conflict-class errors from other errors.
+
+Found during ce:review interactive re-review of PR #68 (reliability P3, confidence 0.70).
+
+## Affected Files
+
+- `cmd/andamio/course_teacher_ops.go:247-252` — the DRAFT-advance branch in `registerOrRecoverModule`
+
+## Proposed Fix
+
+Wrap the `postUpdateModuleStatus` call inside the DRAFT branch with conflict-aware recovery. On update-status error:
+
+1. If the error is a `*apierr.ConflictError` whose body indicates the module is no longer in DRAFT (or a similar "status already past DRAFT" wording), re-invoke `lookupTeacherModule` to read the current status.
+2. If the re-read shows APPROVED / PENDING_TX / ON_CHAIN with matching hash, fold the result into the existing `already_registered` envelope — treat as success, exit 0.
+3. If the re-read shows a different slt_hash or an unexpected status, surface the original `advancing to APPROVED failed: ...` error as today.
+
+Alternative (simpler): extract a second `isStatusTransitionConflict` predicate and apply the same loop. Needs explicit testing.
+
+## Acceptance
+
+- [ ] A new test case in `TestRegisterOrRecoverModule` simulating a concurrent race: register returns 409, lookup returns DRAFT, update-status returns 409 (simulating another agent having advanced the module). Assert the envelope returns `action: "already_registered"` with the current gateway status.
+- [ ] Handler logic re-reads status when update-status returns a conflict-class error on the DRAFT branch.
+- [ ] Envelope `status` field reflects the current gateway state, not the expected APPROVED.
+- [ ] Existing `TestRegisterOrRecoverModule` subtests continue to pass unchanged.
+
+## Context
+
+- **ce:review run artifact:** `.context/compound-engineering/ce-review/2026-04-22-pr68-conflict-error/findings.md`
+- **Origin PR:** https://github.com/Andamio-Platform/andamio-cli/pull/68 (finding surfaced during interactive re-review after the autofix pass)
+- **Related:** `todos/021-pending-p2-verify-gateway-409-for-duplicate-module.md` — if the gateway's 409 wording for status-transition conflicts is captured as part of the P2 preprod verification, use that body format for the test fixture here too.

--- a/todos/023-pending-p3-typed-error-body-truncation-boundary.md
+++ b/todos/023-pending-p3-typed-error-body-truncation-boundary.md
@@ -1,0 +1,71 @@
+---
+status: pending
+priority: p3
+issue_id: "023"
+tags: [code-review, reliability, internal-client, truncation, pr-68-followup]
+dependencies: []
+---
+
+# Error Body Truncation Can Hide Three-Gate Predicate Tokens
+
+## Problem Statement
+
+`internal/client/client.go` truncates non-2xx response bodies at `maxErrorBodySize = 500` characters before wrapping them into typed errors (including `*apierr.ConflictError`). The three-gate predicate in `isModuleAlreadyExistsError` does `strings.Contains` against the truncated `Message`:
+
+```go
+msg := strings.ToLower(conflict.Message)
+return strings.Contains(msg, "already exists") && strings.Contains(msg, "course_module_code")
+```
+
+If the gateway ever prefixes a 409 body with verbose context — a request ID, validation breakdown, stack-like metadata, or nested error envelope — such that the `"course_module_code"` or `"already exists"` token lands past byte 500, the `truncateErrorBody` output will contain neither required token (or only one), the predicate returns false, and `register-module` idempotency silently regresses to `"failed to register module: ..."`.
+
+Today's preprod 409 bodies are short enough that this is theoretical. Post-PR-#68 the interaction is load-bearing: the type gate (`errors.As(*ConflictError)`) confirms the conflict; the body gates narrow which 409 it is. Both body gates depend on the tokens surviving truncation.
+
+Found during ce:review interactive re-review of PR #68 (cross-reviewer consensus — reliability 0.62 + correctness residual 0.55, merged confidence 0.72).
+
+## Affected Files
+
+- `internal/client/client.go:20` — `maxErrorBodySize = 500` constant
+- `internal/client/client.go:187-193` — `truncateErrorBody` implementation
+- `internal/client/client.go:62, 119, 168` — the three call sites that construct typed errors from truncated bodies
+- `cmd/andamio/course_teacher_ops.go:306-307` — the predicate that consumes the truncated `Message`
+
+## Options
+
+### Option A (minimal, low effort)
+
+Raise `maxErrorBodySize` from 500 to 2048. Rationale: error bodies don't drive the happy path; 2 KB of log spam beats a silent idempotency regression. The truncation was introduced to prevent log flooding / info leakage — 2 KB still respects that goal for typical payloads.
+
+### Option B (preserve raw body separately on typed errors)
+
+Introduce a `RawBody` field on typed errors (`NotFoundError`, `AuthError`, `ConflictError`) that holds the untruncated response body. `Message` continues to use the truncated display string. Predicates that need the full body for programmatic checks read `RawBody` directly:
+
+```go
+type ConflictError struct {
+    Message string
+    RawBody string // full response body, untruncated, for programmatic parsing
+}
+```
+
+Requires updating `internal/client/client.go` error construction to capture both, and `isModuleAlreadyExistsError` to prefer `RawBody` when non-empty.
+
+Behavioral change — slightly larger, but cleaner separation of display vs. parseable content.
+
+### Option C (do nothing)
+
+Accept the theoretical risk. Rely on the P2 preprod capture (todo #021) to confirm actual body sizes. Downgrade urgency unless the capture shows bodies approaching or exceeding 500 bytes.
+
+**Preferred:** Option C unless todo #021 surfaces a body > 400 bytes (gives margin for gateway wording drift). If it does, Option A is the cheap fix.
+
+## Acceptance
+
+- [ ] Complete todo #021 first to capture a real 409 body and measure its size.
+- [ ] If the captured body is > 400 bytes: apply Option A (raise `maxErrorBodySize` to 2048) with a comment explaining the interaction with the three-gate predicate.
+- [ ] If Option A is applied: add a test to `internal/client/client_test.go` covering `truncateErrorBody` at the new boundary, AND a test to `TestIsModuleAlreadyExistsError` with a ConflictError whose body is 1900+ bytes and whose tokens sit past byte 500.
+- [ ] If the captured body is < 400 bytes: close this todo as "verified — truncation boundary not load-bearing for current gateway."
+
+## Context
+
+- **ce:review run artifact:** `.context/compound-engineering/ce-review/2026-04-22-pr68-conflict-error/findings.md`
+- **Dependency:** `todos/021-pending-p2-verify-gateway-409-for-duplicate-module.md` — blocks Option A/C decision on the actual body size measurement.
+- **Origin PR:** https://github.com/Andamio-Platform/andamio-cli/pull/68 (surfaced during interactive re-review after the autofix pass).


### PR DESCRIPTION
## Summary

Closes #64. Adds `apierr.ConflictError` alongside the existing `NotFoundError`/`AuthError` types, surfaces it from `client.Get`/`Post`/`Put` for HTTP 409, and migrates `isModuleAlreadyExistsError` (the sole caller) from pure string matching to a three-gate check: `errors.As(*ConflictError)` + `"already exists"` + `"course_module_code"`. Closes out the TODO that PR #63 left pointing at "once that refactor lands" and applies the anti-pattern lesson from `docs/solutions/feature-implementations/cli-course-module-management-commands.md`.

## Plan

`docs/plans/2026-04-22-001-refactor-typed-conflict-error-plan.md` (status: completed). Deepened via document-review — cross-persona consensus overturned an earlier plan decision to drop the `"already exists"` stem check; the final design keeps all three gates for defense-in-depth. See the plan's Risks & Dependencies table for the specific scenarios each gate guards against.

## What's in the two commits

1. **`feat(apierr): typed ConflictError for HTTP 409`** — Type definition (mirrors `NotFoundError`/`AuthError` shape), insertion after the 404 case in all three `client.go` switch blocks (numeric-order preserved), and a new `internal/client/client_test.go` that pins the status-code → error-type mapping for 401/403/404/409/500 across `Get`/`Post`/`Put`. The wrap-chain test proves `errors.As` walks through `fmt.Errorf(%w)` — the property `mismatchError` in register-module depends on.

2. **`refactor(course): migrate isModuleAlreadyExistsError to errors.As`** — Call-site migration. `TestIsModuleAlreadyExistsError` expanded from 9 to 14 cases to independently assert each of the three gates: type-gate negatives (NotFoundError / AuthError / plain error / 5xx-mentioning-tokens all return false), stem-gate negatives (`"course_module_code must be numeric"` returns false), field-gate negatives (`"teacher already exists"` returns false), plus a wrap-chain happy path. `TestRegisterOrRecoverModule` needs no changes — it already drove 409 through real httptest, and now produces `*apierr.ConflictError` end-to-end without test modification.

## Test plan

- [x] `go test ./...` — all pass (17 new client tests + 14 updated isModuleAlreadyExistsError cases + all prior course-teacher-ops tests unchanged)
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `grep 'TODO.*ConflictError' cmd/andamio/` — no matches (plan-specified verification; the TODO is satisfied)
- [x] `grep 'errors.As' cmd/andamio/course_teacher_ops.go` — shows the new usage
- [x] `grep '"already exists"' cmd/andamio/course_teacher_ops.go` — still present (stem check retained per the deepened plan)
- [ ] **Capture a real preprod 409 response body for a duplicate register-module POST** — plan's Risks table mitigation. Not blocking merge on its own (the three-gate predicate is defensive across status-code drift), but recommended before the next 409-handling command lands, so we know whether to widen `ConflictError` to other status codes.

## Post-Deploy Monitoring & Validation

No runtime/production behavior change. User-visible `register-module` behavior is identical (same stderr messages, same `--output json` envelope, same exit codes). The refactor is internal:

- **What changes in production:** the error chain from `client.Post` now carries `*apierr.ConflictError` on 409 responses. `main.go`'s `errors.As` chain does not map this to a distinct exit code (deferred per plan), so unhandled 409s continue to exit 1 as before.
- **Signals to watch:** none specific to this PR. If `register-module` starts erroring on conflicts that previously recovered (idempotency regression), check whether the gateway reworded its 409 body or changed the status code — the three-gate predicate would filter either drift.
- **Rollback trigger:** idempotency regression in `register-module` — revert these two commits.
- **Validation window:** one-time, at next real register-module exercise against preprod.

## Scope boundaries honored

- Not added: typed errors for 422/429 (deferred, non-goal per #64)
- Not added: a new exit code for conflict (deferred; register-module internalizes conflict into its recovery flow)
- Not done: extracting the 3× duplicated status switch in `client.go` (deferred; trigger documented as "the 5th typed-error case")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Demo

Pure backend refactor — no UI, no routes, no user-visible surface. The equivalent "demo" is the new test suite proving the status-code → typed-error mapping at the client layer and the three-gate predicate at the call site.

**`internal/client` — status-code to typed-error mapping across Get/Post/Put (new test file):**

```
PASS: TestClient_StatusCodeToTypedError/Get/401_→_AuthError
PASS: TestClient_StatusCodeToTypedError/Get/403_→_AuthError
PASS: TestClient_StatusCodeToTypedError/Get/404_→_NotFoundError
PASS: TestClient_StatusCodeToTypedError/Get/409_→_ConflictError
PASS: TestClient_StatusCodeToTypedError/Get/500_→_plain_error_(fall-through;_no_typed_match)
PASS: TestClient_StatusCodeToTypedError/Post/401_→_AuthError
PASS: TestClient_StatusCodeToTypedError/Post/403_→_AuthError
PASS: TestClient_StatusCodeToTypedError/Post/404_→_NotFoundError
PASS: TestClient_StatusCodeToTypedError/Post/409_→_ConflictError
PASS: TestClient_StatusCodeToTypedError/Post/500_→_plain_error_(fall-through;_no_typed_match)
PASS: TestClient_StatusCodeToTypedError/Put/401_→_AuthError
PASS: TestClient_StatusCodeToTypedError/Put/403_→_AuthError
PASS: TestClient_StatusCodeToTypedError/Put/404_→_NotFoundError
PASS: TestClient_StatusCodeToTypedError/Put/409_→_ConflictError
PASS: TestClient_StatusCodeToTypedError/Put/500_→_plain_error_(fall-through;_no_typed_match)
```

**`cmd/andamio` — three-gate predicate with isolated gate-negative coverage:**

```
PASS: TestIsModuleAlreadyExistsError/ConflictError_with_'already_exists'_and_course_module_code
PASS: TestIsModuleAlreadyExistsError/ConflictError_case-insensitive_(mixed_case_body)
PASS: TestIsModuleAlreadyExistsError/ConflictError_mentioning_course_module_code_but_no_'already_exists'_stem_(validation_409)
PASS: TestIsModuleAlreadyExistsError/ConflictError_'course_module_code_must_be_numeric'_(different_stem)
PASS: TestIsModuleAlreadyExistsError/ConflictError_'module_already_exists'_without_course_module_code_token
PASS: TestIsModuleAlreadyExistsError/ConflictError_'asset_module_already_exists'_adjacent_wording
PASS: TestIsModuleAlreadyExistsError/ConflictError_'teacher_already_exists'_(different_resource)
PASS: TestIsModuleAlreadyExistsError/nil
PASS: TestIsModuleAlreadyExistsError/plain_errors.New_unrelated
PASS: TestIsModuleAlreadyExistsError/plain_errors.New_whose_body_contains_both_tokens_(non-typed)
PASS: TestIsModuleAlreadyExistsError/proxied_5xx_body_mentioning_tokens_(not_a_ConflictError)
PASS: TestIsModuleAlreadyExistsError/NotFoundError_(wrong_type,_404)
PASS: TestIsModuleAlreadyExistsError/AuthError_(wrong_type,_401/403)
PASS: TestIsModuleAlreadyExistsError/wrapped_ConflictError_(via_fmt.Errorf_%w)
```

Each row in the second block exercises one of the three gates (type / "already exists" stem / "course_module_code" field) in isolation — a regression that drops any gate fails the corresponding row.

*Browser-video walkthrough not applicable to this refactor; test output above is the functional equivalent for a CLI-internal change.*