### PR TITLE
fix: three quick-win UX fixes (closes #60, #61, #62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/
 ## [Unreleased]
 
 ### Added
+- `course import --show-payload` (and `course import-all --show-payload`) — emit the full Tiptap JSON payload on `--dry-run`. Default dry-run is now summary-only; scripts that previously had to `tail -20` past hundreds of lines of JSON to reach the summary no longer need to. When `--show-payload` is set, the payload prints to stderr (not stdout) so piped JSON consumers remain unaffected (#61).
 - `CHANGELOG.md` at the repo root as the source of truth for user-facing release notes (#67).
 - `andamio --version --output json` emits `{version, commit, built}` as structured JSON. `commit` is the 7-character short form matching the plain-text `--version` output; `built` is the verbatim ldflag-injected timestamp (RFC3339 UTC for goreleaser builds; `"unknown"` for dev builds without ldflags). Plain-text `--version` output now uses the same 7-character short commit for both release and dev builds (#67).
 - `scripts/release.sh` preflight check that warns when the target version has no heading in `CHANGELOG.md` before tagging (#67).
@@ -25,6 +26,10 @@ The format follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/
 - `register-module` recovery now tolerates transient gateway failures. The teacher-modules-list lookup that runs after a 409 conflict retries up to 3 times on 5xx or network errors before giving up. Users may see a brief "retrying..." note on stderr during recovery (suppressed in `--output json` mode); scripts that strictly parse stderr content should note the possible new lines (#65).
 - **Cosmetic JSON ordering (`course teacher register-module` with `--output json`):** envelope keys now emit in declaration order (`action, status, slt_hash, advanced_from, response`) rather than alphabetical order (`action, advanced_from, response, slt_hash, status`). Consumers parsing JSON with `jq` / `JSON.parse` see identical data; byte-for-byte output-diff consumers will see a diff. Same five keys, same types, same null semantics (#66).
 - `course teacher register-module` `--output json` envelope's `slt_hash` on the `already_registered` branch now reflects the canonical stored hash (from the teacher modules list) rather than echoing the supplied input. A caller that registers with `"ABC123"` against a module stored as `"abc123"` now sees `.slt_hash == "abc123"` in the envelope, matching what `course modules --output json` returns for the same module. The `registered` and `advanced` branches continue to fall back to the supplied hash when the gateway response is minimal (today's observed behavior) — the asymmetry is documented; full gateway-state population on those branches lights up automatically when real preprod fixtures land (#66, todo #021).
+
+### Fixed
+- `user status` no longer prints `User ID: undefined` when the browser wallet-auth callback returned a literal `"undefined"` or `"null"` URL query value. New `sanitizeCallbackValue` helper drops those JavaScript-style literals (plus pure whitespace) at the store site, so historic configs don't leak them either. The `--output json` envelope already used `omitempty` on `user_id`; sanitization keeps the JSON output aligned with the text output (#60).
+- `course import` now errors loudly when the gateway reports 0 SLTs created AND 0 updated but the local module had SLTs to apply. Previously this silently succeeded with `slts_created: 0`, which also caused all subsequent lesson imports to no-op (no SLT slots to attach to). The guard fires only when SLTs were sent (module not locked) and is bypassed on `--dry-run` (#62).
 
 ## [0.11.2] - 2026-04-08
 

--- a/cmd/andamio/course_import.go
+++ b/cmd/andamio/course_import.go
@@ -275,25 +275,9 @@ func importModule(p ImportParams) (*ImportResult, error) {
 		changes = map[string]interface{}{}
 	}
 
-	// Safety net: loudly surface the silent-SLT-failure mode from issue #62.
-	// If the caller sent SLTs and the module was unlocked (so we expected the
-	// gateway to apply them), but the response shows neither creates nor
-	// updates, something upstream swallowed them. Without this guard, the
-	// lesson attachments that follow also silently fail (no SLT slots to
-	// attach to), and the user sees a "successful" import with no content.
-	// Skip on dry-run (the `changes` map is synthetic there).
-	if !p.DryRun && !sltsLocked && len(data.SLTs) > 0 {
-		created, _ := changes["slts_created"].(float64)
-		updated, _ := changes["slts_updated"].(float64)
-		if created == 0 && updated == 0 {
-			return nil, fmt.Errorf(
-				"import reported 0 SLTs created and 0 updated, but the module had %d SLT(s) to apply. "+
-					"This usually means the module existed with 0 SLTs and the gateway rejected the payload silently. "+
-					"Re-run with --output json and inspect .changes to see the full response; "+
-					"if the module is truly fresh, verify it was created via 'andamio course create-module' (which seeds SLTs correctly) "+
-					"rather than a raw curl to /course-module/create",
-				len(data.SLTs))
-		}
+	// Safety net for issue #62 silent-SLT-failure mode.
+	if err := checkSilentSLTFailure(p.DryRun, sltsLocked, existing.SLTCount, len(data.SLTs), changes); err != nil {
+		return nil, err
 	}
 
 	return &ImportResult{
@@ -313,6 +297,41 @@ func importModule(p ImportParams) (*ImportResult, error) {
 		DryRun:         p.DryRun,
 		Changes:        changes,
 	}, nil
+}
+
+// checkSilentSLTFailure returns an error describing issue #62's silent-SLT-
+// failure mode when the preconditions match. Returns nil otherwise.
+//
+// The scoped condition (existingSLTCount == 0) is deliberate:
+//   - Fresh shell (SLTCount == 0) + 0 creates/updates = gateway rejected
+//     the payload silently. This is exactly the bug #62 describes.
+//   - Module had SLTs and user re-imports identical ones = gateway
+//     returns 0 creates + 0 updates because nothing changed. Legitimate
+//     idempotent success. Guard MUST NOT fire here.
+//
+// Without the SLTCount check the guard false-positives on every
+// unchanged re-import (reported during ce:review of PR #73).
+//
+// Type assertions use the blank identifier deliberately: missing keys
+// default to 0, which is the same signal as explicit 0 values — both
+// indicate the gateway didn't confirm SLT handling, so the guard
+// should fire either way.
+func checkSilentSLTFailure(dryRun, sltsLocked bool, existingSLTCount, newSLTCount int, changes map[string]interface{}) error {
+	if dryRun || sltsLocked || newSLTCount == 0 || existingSLTCount != 0 {
+		return nil
+	}
+	created, _ := changes["slts_created"].(float64)
+	updated, _ := changes["slts_updated"].(float64)
+	if created != 0 || updated != 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"import reported 0 SLTs created and 0 updated, but the module had %d SLT(s) to apply and was freshly-shelled (0 existing SLTs). "+
+			"This usually means the gateway rejected the payload silently. "+
+			"Re-run with --output json and inspect .changes to see the full response; "+
+			"if the module is truly fresh, verify it was created via 'andamio course create-module' (which seeds SLTs correctly) "+
+			"rather than a raw curl to /course-module/create",
+		newSLTCount)
 }
 
 func runCourseImport(cmd *cobra.Command, args []string) error {

--- a/cmd/andamio/course_import.go
+++ b/cmd/andamio/course_import.go
@@ -275,6 +275,27 @@ func importModule(p ImportParams) (*ImportResult, error) {
 		changes = map[string]interface{}{}
 	}
 
+	// Safety net: loudly surface the silent-SLT-failure mode from issue #62.
+	// If the caller sent SLTs and the module was unlocked (so we expected the
+	// gateway to apply them), but the response shows neither creates nor
+	// updates, something upstream swallowed them. Without this guard, the
+	// lesson attachments that follow also silently fail (no SLT slots to
+	// attach to), and the user sees a "successful" import with no content.
+	// Skip on dry-run (the `changes` map is synthetic there).
+	if !p.DryRun && !sltsLocked && len(data.SLTs) > 0 {
+		created, _ := changes["slts_created"].(float64)
+		updated, _ := changes["slts_updated"].(float64)
+		if created == 0 && updated == 0 {
+			return nil, fmt.Errorf(
+				"import reported 0 SLTs created and 0 updated, but the module had %d SLT(s) to apply. "+
+					"This usually means the module existed with 0 SLTs and the gateway rejected the payload silently. "+
+					"Re-run with --output json and inspect .changes to see the full response; "+
+					"if the module is truly fresh, verify it was created via 'andamio course create-module' (which seeds SLTs correctly) "+
+					"rather than a raw curl to /course-module/create",
+				len(data.SLTs))
+		}
+	}
+
 	return &ImportResult{
 		CourseID:       p.CourseID,
 		ModuleCode:     data.ModuleCode,

--- a/cmd/andamio/course_import.go
+++ b/cmd/andamio/course_import.go
@@ -43,7 +43,8 @@ func init() {
 	courseCmd.AddCommand(courseImportCmd)
 	courseImportCmd.Flags().String("course-id", "", "Course ID to import into")
 	courseImportCmd.Flags().String("course", "", "Course name or substring (alternative to --course-id)")
-	courseImportCmd.Flags().Bool("dry-run", false, "Show the API payload without sending it")
+	courseImportCmd.Flags().Bool("dry-run", false, "Preview the import without sending. Shows summary only; use --show-payload to also emit the full API payload")
+	courseImportCmd.Flags().Bool("show-payload", false, "Also print the full API payload (Tiptap JSON etc.) on --dry-run. Noisy for multi-lesson modules")
 	courseImportCmd.Flags().Bool("create", false, "Create the module if it doesn't exist")
 	courseImportCmd.Flags().Int("sort-order", 0, "Sort order when creating a new module (used with --create)")
 }
@@ -133,15 +134,16 @@ type ImportResult struct {
 
 // ImportParams holds the parameters for importing a single module.
 type ImportParams struct {
-	Ctx        context.Context
-	Client     *client.Client
-	Config     *config.Config
-	ModuleDir  string
-	CourseID   string
-	CreateMode bool
-	DryRun     bool
-	SortOrder  int
-	Quiet      bool // suppress progress output (JSON mode)
+	Ctx         context.Context
+	Client      *client.Client
+	Config      *config.Config
+	ModuleDir   string
+	CourseID    string
+	CreateMode  bool
+	DryRun      bool
+	ShowPayload bool // when DryRun, also print the full API payload to stdout
+	SortOrder   int
+	Quiet       bool // suppress progress output (JSON mode)
 }
 
 // importModule is the shared orchestration logic for importing a single module.
@@ -262,7 +264,7 @@ func importModule(p ImportParams) (*ImportResult, error) {
 	}
 
 	// Update the module via API (or dump payload in dry-run mode)
-	resp, err := updateModuleContent(p.Ctx, p.Client, p.CourseID, data, existing, sltsLocked, p.DryRun)
+	resp, err := updateModuleContent(p.Ctx, p.Client, p.CourseID, data, existing, sltsLocked, p.DryRun, p.ShowPayload)
 	if err != nil {
 		return nil, err
 	}
@@ -296,6 +298,7 @@ func runCourseImport(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	moduleDir := args[0]
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	showPayload, _ := cmd.Flags().GetBool("show-payload")
 	createMode, _ := cmd.Flags().GetBool("create")
 	sortOrder, _ := cmd.Flags().GetInt("sort-order")
 	isJSON := output.GetFormat() == output.FormatJSON
@@ -327,15 +330,16 @@ func runCourseImport(cmd *cobra.Command, args []string) error {
 	c := client.New(cfg)
 
 	importResult, err := importModule(ImportParams{
-		Ctx:        ctx,
-		Client:     c,
-		Config:     cfg,
-		ModuleDir:  moduleDir,
-		CourseID:   courseID,
-		CreateMode: createMode,
-		DryRun:     dryRun,
-		SortOrder:  sortOrder,
-		Quiet:      isJSON,
+		Ctx:         ctx,
+		Client:      c,
+		Config:      cfg,
+		ModuleDir:   moduleDir,
+		CourseID:    courseID,
+		CreateMode:  createMode,
+		DryRun:      dryRun,
+		ShowPayload: showPayload,
+		SortOrder:   sortOrder,
+		Quiet:       isJSON,
 	})
 	if err != nil {
 		return err
@@ -1187,7 +1191,7 @@ func fetchExistingModule(ctx context.Context, c *client.Client, courseID, module
 	return nil, fmt.Errorf("%w: '%s' in course '%s'", errModuleNotFound, moduleCode, courseID)
 }
 
-func updateModuleContent(ctx context.Context, c *client.Client, courseID string, data *ImportData, existing *ExistingModuleData, sltsLocked bool, dryRun bool) (map[string]interface{}, error) {
+func updateModuleContent(ctx context.Context, c *client.Client, courseID string, data *ImportData, existing *ExistingModuleData, sltsLocked bool, dryRun bool, showPayload bool) (map[string]interface{}, error) {
 	isJSON := output.GetFormat() == output.FormatJSON
 
 	// Build local lessons indexed by SLT number
@@ -1337,15 +1341,18 @@ func updateModuleContent(ctx context.Context, c *client.Client, courseID string,
 		payload["assignment"] = assign
 	}
 
-	// Dry-run: dump payload as JSON instead of sending
+	// Dry-run: return the payload envelope. In text mode, the handler
+	// renders the summary first; the full JSON payload is printed only
+	// when the caller passes --show-payload. Keeps stderr/stdout noise
+	// proportional to what's useful by default (closes #61).
 	if dryRun {
 		payloadJSON, err := json.MarshalIndent(payload, "", "  ")
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal payload: %w", err)
 		}
-		if output.GetFormat() != output.FormatJSON {
-			fmt.Println("Dry-run payload (not sent):")
-			fmt.Println(string(payloadJSON))
+		if showPayload && output.GetFormat() != output.FormatJSON {
+			fmt.Fprintln(os.Stderr, "Dry-run payload (not sent):")
+			fmt.Fprintln(os.Stderr, string(payloadJSON))
 		}
 		return map[string]interface{}{
 			"dry_run": true,

--- a/cmd/andamio/course_import_all.go
+++ b/cmd/andamio/course_import_all.go
@@ -20,7 +20,8 @@ func init() {
 	courseImportAllCmd.Flags().String("course-id", "", "Course ID to import into")
 	courseImportAllCmd.Flags().String("course", "", "Course name or substring (alternative to --course-id)")
 	courseImportAllCmd.Flags().Bool("create", false, "Create modules that don't exist")
-	courseImportAllCmd.Flags().Bool("dry-run", false, "Show what would be imported without sending")
+	courseImportAllCmd.Flags().Bool("dry-run", false, "Show what would be imported without sending. Summary-only; use --show-payload to also emit full API payloads per module")
+	courseImportAllCmd.Flags().Bool("show-payload", false, "Also print full API payloads on --dry-run. Noisy across many modules")
 	courseImportAllCmd.Flags().Bool("continue-on-error", false, "Continue past failures")
 	courseImportAllCmd.Flags().Int("sort-order-start", 0, "Starting sort order for --create (increments per module)")
 }
@@ -66,6 +67,7 @@ func runImportAll(cmd *cobra.Command, args []string) error {
 	baseDir := args[0]
 	createMode, _ := cmd.Flags().GetBool("create")
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	showPayload, _ := cmd.Flags().GetBool("show-payload")
 	continueOnError, _ := cmd.Flags().GetBool("continue-on-error")
 	sortOrderStart, _ := cmd.Flags().GetInt("sort-order-start")
 	isJSON := output.GetFormat() == output.FormatJSON
@@ -124,7 +126,7 @@ func runImportAll(cmd *cobra.Command, args []string) error {
 		moduleDir := filepath.Join(baseDir, dirName)
 		sortOrder := sortOrderStart + i
 
-		summary := importSingleModule(ctx, c, cfg, moduleDir, courseID, createMode, dryRun, sortOrder, isJSON)
+		summary := importSingleModule(ctx, c, cfg, moduleDir, courseID, createMode, dryRun, showPayload, sortOrder, isJSON)
 		summaries = append(summaries, summary)
 
 		if summary.Error != "" {
@@ -172,7 +174,7 @@ func runImportAll(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func importSingleModule(ctx context.Context, c *client.Client, cfg *config.Config, moduleDir, courseID string, createMode, dryRun bool, sortOrder int, isJSON bool) ModuleImportSummary {
+func importSingleModule(ctx context.Context, c *client.Client, cfg *config.Config, moduleDir, courseID string, createMode, dryRun, showPayload bool, sortOrder int, isJSON bool) ModuleImportSummary {
 	summary := ModuleImportSummary{Dir: filepath.Base(moduleDir)}
 
 	if !isJSON {
@@ -190,15 +192,16 @@ func importSingleModule(ctx context.Context, c *client.Client, cfg *config.Confi
 
 	// Delegate to shared import orchestration
 	result, err := importModule(ImportParams{
-		Ctx:        ctx,
-		Client:     c,
-		Config:     cfg,
-		ModuleDir:  moduleDir,
-		CourseID:   courseID,
-		CreateMode: createMode,
-		DryRun:     dryRun,
-		SortOrder:  sortOrder,
-		Quiet:      isJSON,
+		Ctx:         ctx,
+		Client:      c,
+		Config:      cfg,
+		ModuleDir:   moduleDir,
+		CourseID:    courseID,
+		CreateMode:  createMode,
+		DryRun:      dryRun,
+		ShowPayload: showPayload,
+		SortOrder:   sortOrder,
+		Quiet:       isJSON,
 	})
 	if err != nil {
 		summary.Error = err.Error()

--- a/cmd/andamio/course_import_test.go
+++ b/cmd/andamio/course_import_test.go
@@ -704,3 +704,99 @@ func TestMarkdownToTiptapTableInlineMarks(t *testing.T) {
 		t.Errorf("expected code mark in table cell")
 	}
 }
+
+// TestCheckSilentSLTFailure pins the guard's decision matrix for issue #62.
+// The guard fires only when all of:
+//   - not a dry-run
+//   - SLTs are not locked (module is DRAFT)
+//   - caller is sending SLTs (newSLTCount > 0)
+//   - module previously had 0 SLTs (existingSLTCount == 0)
+//   - gateway reports 0 creates AND 0 updates
+//
+// The existingSLTCount == 0 gate is the one that prevents false-positives
+// on idempotent re-imports of unchanged SLTs — caught during ce:review
+// of PR #73.
+func TestCheckSilentSLTFailure(t *testing.T) {
+	cases := []struct {
+		name             string
+		dryRun           bool
+		sltsLocked       bool
+		existingSLTCount int
+		newSLTCount      int
+		changes          map[string]interface{}
+		wantErr          bool
+	}{
+		{
+			name:             "fresh shell + gateway silent rejection: guard fires (#62 repro)",
+			existingSLTCount: 0,
+			newSLTCount:      3,
+			changes:          map[string]interface{}{"slts_created": float64(0), "slts_updated": float64(0)},
+			wantErr:          true,
+		},
+		{
+			name:             "fresh shell + missing changes keys: guard fires (assertion defaults to 0)",
+			existingSLTCount: 0,
+			newSLTCount:      3,
+			changes:          map[string]interface{}{},
+			wantErr:          true,
+		},
+		{
+			name:             "idempotent re-import of unchanged SLTs: guard must NOT fire",
+			existingSLTCount: 3, // module already had 3 SLTs
+			newSLTCount:      3,
+			changes:          map[string]interface{}{"slts_created": float64(0), "slts_updated": float64(0)},
+			wantErr:          false, // legitimate no-op; pre-fix this was a false positive
+		},
+		{
+			name:             "partial update: at least one SLT touched, guard must NOT fire",
+			existingSLTCount: 0,
+			newSLTCount:      3,
+			changes:          map[string]interface{}{"slts_created": float64(3), "slts_updated": float64(0)},
+			wantErr:          false,
+		},
+		{
+			name:             "updates only (no creates): guard must NOT fire",
+			existingSLTCount: 3,
+			newSLTCount:      3,
+			changes:          map[string]interface{}{"slts_created": float64(0), "slts_updated": float64(2)},
+			wantErr:          false,
+		},
+		{
+			name:             "dry-run: skip the guard (synthetic changes)",
+			dryRun:           true,
+			existingSLTCount: 0,
+			newSLTCount:      3,
+			changes:          map[string]interface{}{},
+			wantErr:          false,
+		},
+		{
+			name:             "SLTs locked (non-DRAFT module): skip the guard",
+			sltsLocked:       true,
+			existingSLTCount: 0,
+			newSLTCount:      3,
+			changes:          map[string]interface{}{},
+			wantErr:          false,
+		},
+		{
+			name:             "no SLTs sent: skip the guard",
+			existingSLTCount: 0,
+			newSLTCount:      0,
+			changes:          map[string]interface{}{},
+			wantErr:          false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkSilentSLTFailure(tc.dryRun, tc.sltsLocked, tc.existingSLTCount, tc.newSLTCount, tc.changes)
+			if tc.wantErr && err == nil {
+				t.Errorf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("expected nil, got: %v", err)
+			}
+			if tc.wantErr && err != nil && !strings.Contains(err.Error(), "freshly-shelled") {
+				t.Errorf("error should mention 'freshly-shelled' to clarify why the guard fired, got: %v", err)
+			}
+		})
+	}
+}

--- a/cmd/andamio/user.go
+++ b/cmd/andamio/user.go
@@ -177,11 +177,14 @@ func runUserLogin(cmd *cobra.Command, args []string) error {
 			return
 		}
 
-		// Extract JWT and user info
-		result.JWT = r.URL.Query().Get("jwt")
-		result.ExpiresAt = r.URL.Query().Get("expires_at")
-		result.Alias = r.URL.Query().Get("alias")
-		result.UserID = r.URL.Query().Get("user_id")
+		// Extract JWT and user info. sanitizeCallbackValue drops JavaScript-
+		// style "undefined"/"null" literals the browser may serialize when
+		// the field is absent upstream, so they don't land in config as
+		// real strings and surface as `User ID: undefined` on `user status`.
+		result.JWT = sanitizeCallbackValue(r.URL.Query().Get("jwt"))
+		result.ExpiresAt = sanitizeCallbackValue(r.URL.Query().Get("expires_at"))
+		result.Alias = sanitizeCallbackValue(r.URL.Query().Get("alias"))
+		result.UserID = sanitizeCallbackValue(r.URL.Query().Get("user_id"))
 
 		if result.JWT == "" {
 			result.Error = "no JWT received"
@@ -406,7 +409,9 @@ func runUserStatus(cmd *cobra.Command, args []string) error {
 		}
 		if cfg.HasUserAuth() {
 			result.UserAlias = cfg.UserAlias
-			result.UserID = cfg.UserID
+			// Drop "undefined"/"null" from historic configs so the JSON
+			// envelope doesn't carry the same bad value text mode hides.
+			result.UserID = sanitizeCallbackValue(cfg.UserID)
 			if cfg.JWTExpiresAt != "" {
 				result.SessionExpiresAt = cfg.JWTExpiresAt
 				if expiresAt, err := time.Parse(time.RFC3339, cfg.JWTExpiresAt); err == nil {
@@ -438,7 +443,13 @@ func runUserStatus(cmd *cobra.Command, args []string) error {
 	// User JWT status
 	if cfg.HasUserAuth() {
 		fmt.Printf("User: %s\n", cfg.UserAlias)
-		fmt.Printf("User ID: %s\n", cfg.UserID)
+		// Only show User ID when there's a real value. A historic config
+		// written before sanitizeCallbackValue landed may still contain
+		// the literal strings "undefined" or "null" from the browser
+		// callback flow; treat those as absent.
+		if id := cfg.UserID; id != "" && id != "undefined" && id != "null" {
+			fmt.Printf("User ID: %s\n", id)
+		}
 
 		if cfg.JWTExpiresAt != "" {
 			expiresAt, err := time.Parse(time.RFC3339, cfg.JWTExpiresAt)
@@ -620,6 +631,18 @@ func buildAuthURL(baseURL, redirectURI, state string) string {
 	params.Set("state", state)
 
 	return fmt.Sprintf("%s/auth/cli?%s", appURL, params.Encode())
+}
+
+// sanitizeCallbackValue drops JavaScript-style "undefined" / "null" literals
+// and pure whitespace. The browser wallet-auth callback serializes missing
+// fields this way; without this cleanup, they land in ~/.andamio/config.json
+// as real strings and later surface as `User ID: undefined` on user status.
+func sanitizeCallbackValue(v string) string {
+	s := strings.TrimSpace(v)
+	if s == "undefined" || s == "null" {
+		return ""
+	}
+	return s
 }
 
 // formatDuration formats a duration in a human-readable way

--- a/cmd/andamio/user_test.go
+++ b/cmd/andamio/user_test.go
@@ -1,0 +1,33 @@
+package main
+
+import "testing"
+
+// TestSanitizeCallbackValue covers the browser-callback → config → user-status
+// pipeline for missing/undefined fields. Locks issue #60's fix: "User ID:
+// undefined" never reaches the user, whether they're reading text-mode
+// `user status` or parsing `user status --output json`.
+func TestSanitizeCallbackValue(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty stays empty", "", ""},
+		{"normal value passes through", "usr_abc123", "usr_abc123"},
+		{"leading/trailing whitespace trimmed", "  usr_abc  ", "usr_abc"},
+		{"JavaScript undefined literal dropped", "undefined", ""},
+		{"JavaScript null literal dropped", "null", ""},
+		{"whitespace around undefined dropped", "  undefined  ", ""},
+		{"case-sensitive: 'Undefined' is a real value", "Undefined", "Undefined"},
+		{"case-sensitive: 'UNDEFINED' is a real value", "UNDEFINED", "UNDEFINED"},
+		{"whitespace only collapses to empty", "   \t\n  ", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeCallbackValue(tc.in)
+			if got != tc.want {
+				t.Errorf("sanitizeCallbackValue(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Three small, focused UX fixes reported 2026-04-16 against CLI \`0.11.2\`. Each is a standalone commit so they can be cherry-picked or reverted independently if needed.

## Changes

### \`fix(user): drop 'User ID: undefined' from status output\` (#60)

The browser wallet-auth callback stores query-string values verbatim. When the upstream auth flow serialized a missing \`user_id\` as the JavaScript literal \`\"undefined\"\`, it landed in \`~/.andamio/config.json\` as a real string and surfaced as \`User ID: undefined\` on \`andamio user status\`.

- New \`sanitizeCallbackValue\` helper drops \`\"undefined\"\` / \`\"null\"\` literals (plus whitespace) at the store site in \`user.go:180-184\`.
- \`user status\` text output hides the \`User ID:\` line when the value is empty rather than printing \`User ID: \` (blank after the colon).
- \`user status --output json\` already used \`omitempty\`; sanitizing the value means historic \"undefined\" configs don't leak into JSON either.
- Session-expiry info in \`user status\` (the other half of #60) was already implemented.

Test: \`TestSanitizeCallbackValue\` covers 9 input shapes including case-sensitivity — only the exact JS literals (\`undefined\`, \`null\`) are dropped; \`Undefined\`, \`UNDEFINED\`, etc. pass through as real values.

### \`fix(course): dry-run summary first, payload behind --show-payload\` (#61)

\`course import --dry-run\` previously dumped the full Tiptap JSON payload (hundreds of lines per lesson) to stdout before the 8-line summary, forcing scripts to pipe through \`tail -20\` to reach anything useful.

- Default \`--dry-run\` is now summary-only.
- New \`--show-payload\` flag re-enables the full JSON dump (also added to \`course import-all\`).
- When \`--show-payload\` IS set, the payload prints to stderr — composability rule #2 puts diagnostic output there. Scripts consuming \`--output json\` were never affected (payload was always nested under \`.payload\`).

### \`fix(course): loud error on 0-SLTs-created silent failure\` (#62)

The reported symptom: \`course import\` on a fresh module shell returned \`slts_created: 0\` with no error surfaced. Lesson imports in the same run then also silently failed because there were no SLT slots to attach to, producing a \"successful\" import with no content.

The root-cause fix (omitting \`slt_index\` when \`existing.SLTCount == 0\`) had already landed 2026-03-16 at \`course_import.go:1281\` — before 0.11.2 and before this issue was filed. This commit adds the safety net #62 also requested:

- After \`updateModuleContent\` returns, if the module was DRAFT (SLTs unlocked), the user sent SLTs, and the gateway reports \`slts_created: 0 && slts_updated: 0\`, error loudly.
- Error message points at the likely root cause: using a raw curl to \`/course-module/create\` instead of \`andamio course create-module\` (which seeds SLTs correctly).
- Guard skipped on \`--dry-run\` (synthetic \`changes\` map has no real counts).

Note: the \"create-module command is missing\" half of #62 was addressed separately — \`cmd/andamio/course_create_module.go\` is already in main and \`andamio course create-module --help\` renders its full flag set.

## Test Plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./...\` — 100% pass. New test: \`TestSanitizeCallbackValue\` (9 cases). Existing \`course_import\` and \`course_teacher_ops\` tests still pass with the new \`ImportParams.ShowPayload\` field and the \`updateModuleContent\` signature expansion.
- [ ] Manual: \`andamio user status\` on a config with \`user_id: \"undefined\"\` — line should be suppressed
- [ ] Manual: \`andamio course import <path> --course-id <id> --dry-run\` — summary shows first, no JSON dump
- [ ] Manual: \`andamio course import <path> --course-id <id> --dry-run --show-payload\` — payload prints to stderr, summary to stdout

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. These are CLI-side UX fixes; no gateway or infrastructure impact. Scripts that previously matched on the pattern \`User ID: undefined\` in stderr output will see no match after upgrade (acceptable — the pattern was a symptom of the bug being fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)