### PR TITLE
test(evidence): pin commitment-hash parity vector against @andamio/core

### DIFF
--- a/cmd/andamio/commitment_hash_parity_test.go
+++ b/cmd/andamio/commitment_hash_parity_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+
+	"github.com/Andamio-Platform/andamio-cli/internal/cardano"
+)
+
+// TestCommitmentHashParity_CoreTSVector pins one shared vector against the
+// @andamio/core TypeScript implementation of computeCommitmentHash. Both
+// sides must produce the SAME 64-char hex hash for this exact input — any
+// drift in normalizeForHashing (key sorting, string trimming, null handling)
+// or in the JSON serialization / Blake2b-256 step on either side will break
+// this test.
+//
+// Why the vector matters: CLI-submitted evidence must hash to the same
+// value the gateway stores on-chain. If the Go and TS implementations drift,
+// users see "evidence does not match on-chain commitment" errors with no
+// deterministic way to diagnose. This test catches drift at CI time instead.
+//
+// The canonical input exercises:
+//   - a Tiptap doc envelope (type, content)
+//   - nested arrays (content → [paragraph] → content → [text])
+//   - a mix of object keys that sort non-trivially ("attrs" vs "content" vs
+//     "marks" vs "text" vs "type") — key-sort drift would break the hash
+//   - a string with interior whitespace (not just leading/trailing) so the
+//     trim rule is exercised without being a no-op
+//   - a `marks` array with an attribute object nested under it
+//
+// Vector source of truth: compute via
+//
+//	node -e 'import("@andamio/core/hashing").then(m =>
+//	  console.log(m.computeCommitmentHash(<JSON below>)))'
+//
+// Verified 2026-04-24 against andamio-core@<current> built at
+// ~/projects/01-projects/andamio-core/dist/utils/hashing/index.mjs.
+// If this test ever fails after a @andamio/core release, re-run the TS
+// computation and update `want` — then open a follow-up to investigate
+// why the normalization/hash contract changed.
+func TestCommitmentHashParity_CoreTSVector(t *testing.T) {
+	doc := map[string]interface{}{
+		"type": "doc",
+		"content": []interface{}{
+			map[string]interface{}{
+				"type": "paragraph",
+				"content": []interface{}{
+					map[string]interface{}{
+						"type": "text",
+						"text": "My evidence submission",
+						"marks": []interface{}{
+							map[string]interface{}{
+								"type":  "bold",
+								"attrs": map[string]interface{}{"level": 1},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	normalized := normalizeForHashing(doc)
+	b, err := json.Marshal(normalized)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := hex.EncodeToString(cardano.Blake2b256(b))
+
+	// Emitted by @andamio/core computeCommitmentHash on the exact input above.
+	const want = "8bd3d0b5a9c157005616a34f3a6ec7ba5d4b4961cc277d408ddac8e86a17434f"
+
+	if got != want {
+		t.Errorf("Go-TS parity mismatch on canonical Tiptap doc:\n  go  = %s\n  ts  = %s\n  json = %s", got, want, string(b))
+	}
+}


### PR DESCRIPTION
## Summary

Closes the last hash-parity coverage gap between the CLI (Go) and `@andamio/core` (TypeScript). Before this PR, `computeTaskHash` and `computeSltHash` had shared on-chain test vectors pinning cross-language parity — but `computeCommitmentHash` had **none on either side**. Drift between the two implementations would only surface when a user's CLI-submitted evidence silently hashed to a different value than the gateway expected.

One canonical Tiptap doc now pins the parity contract from the CLI side.

## Context

The CLI has **no Go-module dependency** on `@andamio/core`, but three hashing algorithms in Go must produce bit-identical output to the TS implementations:

| Algorithm | Go site | TS site | Pre-PR parity coverage |
|---|---|---|---|
| `computeTaskHash` | `internal/cardano/task_hash.go` | `@andamio/core/hashing/task-hash.ts` | 7 on-chain vectors shared, ✓ guarded |
| `computeSltHash` | `internal/cardano/slt_hash.go` | `@andamio/core/hashing/slt-hash.ts` | 1 on-chain vector shared, ✓ guarded |
| `computeCommitmentHash` | `cmd/andamio/helpers.go:wrapEvidence` | `@andamio/core/hashing/commitment-hash.ts` | **0 shared vectors — drift-silent** |

Spot-checked all three against the live `@andamio/core` build today; tasks and SLTs are in sync and test-protected. Commitment-hash is in sync but not test-protected. This PR adds the test.

## Why it matters

The CLI's `wrapEvidence` path is the hot one for this contract — every `course student submit` or `project contributor update` runs the user's markdown through `markdownToTiptap` → `normalizeForHashing` → `json.Marshal` → `Blake2b-256`. If the Go and TS `normalizeForHashing` diverge on key sorting, string trimming, null handling, or the Tiptap doc's JSON field order, users submitting from the CLI will see "evidence does not match on-chain commitment" errors with no easy diagnostic path. A single shared test vector catches that class of drift at CI time.

## Vector design

The canonical input is chosen to exercise the subtle parts of `normalizeForHashing`:

- Tiptap envelope shape (`type`, `content` keys)
- Nested arrays two levels deep (`content → [paragraph] → content → [text]`)
- Non-trivially-sorted object keys (`attrs`, `content`, `marks`, `text`, `type`) — key-sort drift would break the hash
- A `marks` array carrying an `attrs` object — recursion through heterogeneous nesting
- A text string with interior whitespace (the `TrimSpace` rule trims only leading/trailing, so the interior must pass through unchanged on both sides)

```js
// TS reference input
const doc = {
  type: "doc",
  content: [{
    type: "paragraph",
    content: [{
      type: "text",
      text: "My evidence submission",
      marks: [{ type: "bold", attrs: { level: 1 } }]
    }]
  }]
};

computeCommitmentHash(doc) === "8bd3d0b5a9c157005616a34f3a6ec7ba5d4b4961cc277d408ddac8e86a17434f"
```

Go runs the same doc through `normalizeForHashing` + `json.Marshal` + `cardano.Blake2b256` and produces the same hex.

## Test plan

- [x] `go test -race ./cmd/andamio/ -run TestCommitmentHashParity` passes
- [x] `go test -race ./...` clean
- [x] `go vet ./...` clean
- [x] Vector regenerated from `~/projects/01-projects/andamio-core/dist/utils/hashing/index.mjs` on 2026-04-24 and matches byte-for-byte

## Follow-ups

**Cross-repo test mirror (recommended).** `@andamio/core` has `task-hash.test.ts` and `slt-hash.test.ts` but no `commitment-hash.test.ts`. A one-file addition over there — same input, same expected hash — would make the parity contract bidirectionally enforceable (TS changes would break TS CI, and Go changes already break this test). Not in this PR; happy to open the sibling PR in `andamio-core` as a follow-up if desired.

**If this ever fails after a @andamio/core release**, the test comment walks through the diagnostic: regenerate the hash from the new TS build, update `want`, then investigate why the normalization/hash contract changed. The `want` value is not magic — it's a frozen witness of parity at a specific point in time.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — test-only change, no runtime behavior difference. The test is fast (<10ms) and deterministic; it'll surface drift immediately in CI on any PR that touches the Go normalization or hash path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)