### PR TITLE
fix(dev keys): preserve X-API-Key alongside dev JWT (dual-credential)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/
 
 ## [Unreleased]
 
+### Fixed
+- `andamio dev keys list|create|delete` no longer return 401 against the live gateway. The 0.12.0 implementation cleared `APIKey` from the cloned cfg before sending requests to `/api/v2/keys`, mirroring the `cmd/andamio/apikey.go` "single-credential isolation" pattern. That pattern was incorrect for this surface: the gateway middleware stack on `/api/v2/keys` is **dual** — `V2AuthMiddleware` validates `X-API-Key` for app-level auth and billing, then `developerJWTAuth` validates the developer JWT. Sending dev-JWT alone fails at the first middleware. The clone now preserves `APIKey` and only promotes `DevJWT` into the `UserJWT` slot so both `X-API-Key` and `Authorization: Bearer <devJWT>` ride on the wire. The previous "tests pin no-X-API-Key" assertions in `cmd/andamio/dev_keys_test.go` are flipped to assert the dual-credential contract instead. Both `auth login --api-key <key>` AND `dev login` are now required preconditions for `dev keys` commands; the gateway returns its own 401 if `X-API-Key` is empty.
+
 ## [0.12.0] - 2026-05-06
 
 ### Security

--- a/cmd/andamio/dev_keys.go
+++ b/cmd/andamio/dev_keys.go
@@ -33,18 +33,19 @@ import (
 // stays a documented hazard rather than a tested one.
 var devKeyIDPattern = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
 
-// PR-B (#80 second slice) — wraps andamio-api's `/v2/keys` developer-portal
+// PR-B (#80 second slice) — wraps andamio-api's `/api/v2/keys` developer-portal
 // surface (added in #410, separate from the legacy `/apikey/developer/key/*`
-// POST-with-body routes). All three endpoints require the developer JWT
-// minted by `andamio dev login`; the gateway's `developerJWTAuth` middleware
-// rejects wallet/user JWTs and api-keys-only.
+// POST-with-body routes). The gateway's middleware stack on this surface is
+// **dual**: `V2AuthMiddleware` validates `X-API-Key` for app-level auth and
+// billing, and `developerJWTAuth` validates `Authorization: Bearer <devJWT>`
+// for developer identity. **Both** headers must be on the wire — sending
+// dev-JWT alone returns 401 because V2AuthMiddleware runs first.
 //
-// Routing approach: clone the loaded cfg, clear `APIKey`, promote `DevJWT`
-// into `UserJWT` so `internal/client.setHeaders` emits exactly one credential
-// (`Authorization: Bearer <devJWT>`). Mirrors `cmd/andamio/apikey.go`'s clone
-// pattern. Tracked design choice in #84 item 3 — kept consistent with the
-// existing clone helper rather than introducing a parallel `Client.SetDevJWT`
-// API surface that wouldn't pay for itself today.
+// Routing approach: clone the loaded cfg and promote `DevJWT` into the
+// `UserJWT` slot so `internal/client.setHeaders` emits the dev JWT in the
+// `Authorization` header (rather than the wallet JWT, if one is also stored).
+// `APIKey` is intentionally **preserved** so `X-API-Key` rides alongside.
+// The original cfg is not mutated.
 const (
 	devKeysListPath   = "/api/v2/keys"
 	devKeysCreatePath = "/api/v2/keys"
@@ -58,13 +59,15 @@ var devKeysCmd = &cobra.Command{
 	Short: "Manage developer API keys (mainnet + preprod)",
 	Long: `Developer API key management.
 
-Wraps the gateway's /v2/keys surface — list, create, and delete API keys
-across both mainnet and preprod environments. Authenticates with the
-developer JWT minted by 'andamio dev login'; api-key + wallet-JWT slots
-are not accepted by this endpoint family.
+Wraps the gateway's /api/v2/keys surface — list, create, and delete API
+keys across both mainnet and preprod environments. Requires both an
+X-API-Key (for app-level auth and billing) AND the developer JWT minted
+by 'andamio dev login' (for developer identity). The wallet/user JWT
+slot is not used by this endpoint family.
 
-Run 'andamio dev login --skey <path> --alias <name> --address <bech32>'
-first if you have not yet minted a developer JWT.`,
+Run 'andamio auth login --api-key <key>' AND 'andamio dev login --skey
+<path> --alias <name> --address <bech32>' first if you have not yet
+configured both credentials.`,
 	Args: cobra.NoArgs,
 }
 
@@ -119,18 +122,21 @@ func init() {
 	devKeysCreateCmd.MarkFlagRequired("environment")
 }
 
-// devKeysClient builds an HTTP client with auth headers scoped to the
-// developer JWT only. Clones the loaded cfg, clears `APIKey` so X-API-Key
-// is not also sent (the gateway's `developerJWTAuth` middleware rejects
-// dual-credential requests — past pain in
-// docs/solutions/integration-issues/cli-apikey-auth-isolation-and-content-404-ux.md),
-// and promotes `DevJWT` into the `UserJWT` slot so `setHeaders` emits
-// `Authorization: Bearer <devJWT>` via the existing path. The original cfg
-// is not mutated — callers that subsequently `Save()` write the unchanged
+// devKeysClient builds an HTTP client that emits both `X-API-Key` (for the
+// gateway's `V2AuthMiddleware` app-level auth) and `Authorization: Bearer
+// <devJWT>` (for `developerJWTAuth` developer identity). Both are required
+// on the `/api/v2/keys` surface — see the package-level comment above.
+//
+// Implementation: clone the loaded cfg, promote `DevJWT` into the `UserJWT`
+// slot so `setHeaders` emits the dev JWT (rather than the wallet/user JWT,
+// if one is also stored), and leave `APIKey` in place. The original cfg is
+// not mutated — callers that subsequently `Save()` write the unchanged
 // dev/user/api-key state back to disk.
 //
 // Returns a typed AuthError if the dev slot is empty, with an inline hint
-// pointing at `dev login`.
+// pointing at `dev login`. (An empty `APIKey` slot is not pre-checked here;
+// the gateway will return 401 with its own message, which the caller's
+// `*apierr.AuthError` mapping surfaces.)
 func devKeysClient(cfg *config.Config) (*client.Client, error) {
 	if !cfg.HasDevAuth() {
 		return nil, &apierr.AuthError{
@@ -142,12 +148,10 @@ func devKeysClient(cfg *config.Config) (*client.Client, error) {
 	// field on Config and would otherwise share the underlying map pointer
 	// with the source. Today client.New does not read submit headers and
 	// devKeysClient does not mutate them, so the shared pointer is safe.
-	// But the auth-isolation contract this helper exists to enforce should
-	// be defended structurally, not by current-implementation invariants.
-	// Any future field added to Config that holds a reference type needs
-	// the same explicit handling.
+	// But this helper's contract should be defended structurally, not by
+	// current-implementation invariants. Any future field added to Config
+	// that holds a reference type needs the same explicit handling.
 	devCfg.SubmitHeaders = maps.Clone(cfg.SubmitHeaders)
-	devCfg.APIKey = ""
 	devCfg.UserJWT = cfg.DevJWT
 	return client.New(&devCfg), nil
 }

--- a/cmd/andamio/dev_keys_test.go
+++ b/cmd/andamio/dev_keys_test.go
@@ -19,10 +19,11 @@ import (
 // dev keys list|create|delete — andamio-api /v2/keys (#410, PR-B/#80 second slice)
 // =============================================================================
 
-// devKeysGatewayStub stands in for the /v2/keys endpoint family. Each test
-// wires the response body + status and inspects captured request metadata
-// (method, body, Authorization header) so the no-X-API-Key contract is
-// enforced structurally — not just observed transitively.
+// devKeysGatewayStub stands in for the /api/v2/keys endpoint family. Each
+// test wires the response body + status and inspects captured request
+// metadata (method, body, Authorization header, X-API-Key header) so the
+// dual-credential contract is enforced structurally — not just observed
+// transitively.
 type devKeysGatewayStub struct {
 	listRespStatus int
 	listRespBody   []byte
@@ -39,12 +40,14 @@ type devKeysGatewayStub struct {
 	capturedDeleteID string
 
 	// capturedAuthHeader records the Authorization header from the last
-	// request. Used to assert the dev JWT (NOT the wallet JWT, NOT the
-	// api key) was forwarded.
+	// request. Used to assert the dev JWT (NOT the wallet JWT) was
+	// forwarded — the wallet/user JWT slot is overwritten by the dev JWT
+	// in the cfg clone.
 	capturedAuthHeader string
 	// capturedAPIKeyHeader records X-API-Key from the last request. Must
-	// always be empty on this endpoint family — dual-credential requests
-	// fail with the gateway's middleware.
+	// equal the configured api-key on this endpoint family — the gateway's
+	// V2AuthMiddleware requires it for app-level auth alongside the
+	// developer JWT.
 	capturedAPIKeyHeader string
 }
 
@@ -97,9 +100,10 @@ func (s *devKeysGatewayStub) writeOrDefault(w http.ResponseWriter, status int, b
 }
 
 // devKeysTestEnv wires the stub, points HOME at a tempdir, and seeds a
-// config with both a dev JWT (the credential `dev keys` SHOULD use) and a
-// wallet JWT + api key (credentials it MUST NOT also send). The latter two
-// are tripwires: any test that sees them on the wire fails.
+// config with the dev JWT (which must ride in `Authorization: Bearer`) and
+// the api-key (which must ride in `X-API-Key` alongside it). The wallet/
+// user JWT is a tripwire: it must NOT make it to the wire because the cfg
+// clone overwrites the UserJWT slot with the DevJWT.
 func devKeysTestEnv(t *testing.T, stub *devKeysGatewayStub) *config.Config {
 	t.Helper()
 	srv := httptest.NewServer(stub.serve())
@@ -109,7 +113,7 @@ func devKeysTestEnv(t *testing.T, stub *devKeysGatewayStub) *config.Config {
 
 	cfg := &config.Config{
 		BaseURL:   srv.URL,
-		APIKey:    "tripwire-api-key-MUST-NOT-LEAK",
+		APIKey:    "expected-api-key-on-wire",
 		UserJWT:   "tripwire-user-jwt-MUST-NOT-LEAK",
 		DevJWT:    "dev.jwt.bearer.value",
 		DevAlias:  "myalias",
@@ -126,13 +130,13 @@ func devKeysTestEnv(t *testing.T, stub *devKeysGatewayStub) *config.Config {
 // shared auth-header invariants (one assertion path used by all three commands)
 // -----------------------------------------------------------------------------
 
-func assertOnlyDevJWTOnTheWire(t *testing.T, stub *devKeysGatewayStub) {
+func assertDualCredentialAuthOnTheWire(t *testing.T, stub *devKeysGatewayStub) {
 	t.Helper()
 	if got, want := stub.capturedAuthHeader, "Bearer dev.jwt.bearer.value"; got != want {
 		t.Errorf("Authorization header = %q, want %q (dev JWT must ride here, not wallet JWT)", got, want)
 	}
-	if stub.capturedAPIKeyHeader != "" {
-		t.Errorf("X-API-Key header = %q, want empty (dual-credential requests are rejected by developerJWTAuth middleware)", stub.capturedAPIKeyHeader)
+	if got, want := stub.capturedAPIKeyHeader, "expected-api-key-on-wire"; got != want {
+		t.Errorf("X-API-Key header = %q, want %q (V2AuthMiddleware requires X-API-Key alongside the dev JWT — sending dev JWT alone returns 401)", got, want)
 	}
 }
 
@@ -155,7 +159,7 @@ func TestRunDevKeysList_HappyPath_DecodesAndPassesAuthHeaderCorrectly(t *testing
 	if !stub.gotListRequest {
 		t.Fatal("list endpoint not called")
 	}
-	assertOnlyDevJWTOnTheWire(t, stub)
+	assertDualCredentialAuthOnTheWire(t, stub)
 }
 
 func TestRunDevKeysList_JSONOutput_PassesGatewayShapeVerbatim(t *testing.T) {
@@ -279,7 +283,7 @@ func TestRunDevKeysCreate_HappyPath_RawKeyOnStdoutWarningOnStderr(t *testing.T) 
 	if !stub.gotCreateRequest {
 		t.Fatal("create endpoint not called")
 	}
-	assertOnlyDevJWTOnTheWire(t, stub)
+	assertDualCredentialAuthOnTheWire(t, stub)
 
 	// Body shape: name + environment forwarded verbatim.
 	if got := stub.capturedCreate["name"]; got != "preprod-bot" {
@@ -413,7 +417,7 @@ func TestRunDevKeysDelete_HappyPath_204(t *testing.T) {
 	if got := stub.capturedDeleteID; got != validID {
 		t.Errorf("captured id = %q, want %q", got, validID)
 	}
-	assertOnlyDevJWTOnTheWire(t, stub)
+	assertDualCredentialAuthOnTheWire(t, stub)
 }
 
 // TestRunDevKeysDelete_RejectsMalformedID pins the client-side UUID gate.
@@ -502,17 +506,17 @@ func TestRunDevKeysDelete_JSONEnvelope(t *testing.T) {
 }
 
 // -----------------------------------------------------------------------------
-// devKeysClient — the auth-isolation primitive (the load-bearing security guard)
+// devKeysClient — the dual-credential primitive (the load-bearing security guard)
 // -----------------------------------------------------------------------------
 
-func TestDevKeysClient_StripsAPIKeyAndPromotesDevJWT(t *testing.T) {
+func TestDevKeysClient_PreservesAPIKeyAndPromotesDevJWT(t *testing.T) {
 	// Seed SubmitHeaders too so the deep-clone contract is observable via
 	// the source-not-mutated invariant below (the production code calls
 	// maps.Clone(cfg.SubmitHeaders) explicitly to break the shared-pointer
 	// hazard).
 	cfg := &config.Config{
-		APIKey:  "should-be-stripped",
-		UserJWT: "wallet-jwt-should-not-promote",
+		APIKey:  "api-key-must-ride",
+		UserJWT: "wallet-jwt-must-not-promote",
 		DevJWT:  "dev-jwt-should-be-bearer",
 		SubmitHeaders: map[string]string{
 			"project_id": "blockfrost-secret-MUST-NOT-LEAK",
@@ -529,10 +533,10 @@ func TestDevKeysClient_StripsAPIKeyAndPromotesDevJWT(t *testing.T) {
 	// access on the unexported client struct would couple to internals.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got, want := r.Header.Get("Authorization"), "Bearer dev-jwt-should-be-bearer"; got != want {
-			t.Errorf("Authorization = %q, want %q", got, want)
+			t.Errorf("Authorization = %q, want %q (dev JWT must ride here; the cfg clone promotes DevJWT into the UserJWT slot)", got, want)
 		}
-		if got := r.Header.Get("X-API-Key"); got != "" {
-			t.Errorf("X-API-Key = %q, want empty (dual-credential requests are rejected)", got)
+		if got, want := r.Header.Get("X-API-Key"), "api-key-must-ride"; got != want {
+			t.Errorf("X-API-Key = %q, want %q (V2AuthMiddleware requires X-API-Key for app-level auth alongside the developer JWT)", got, want)
 		}
 		// Submit headers are Cardano-side concerns; they MUST NOT ride on
 		// dev-portal requests. The current Client doesn't read SubmitHeaders
@@ -540,7 +544,7 @@ func TestDevKeysClient_StripsAPIKeyAndPromotesDevJWT(t *testing.T) {
 		// refactor wires submit headers into request emission, this test
 		// catches it.
 		if got := r.Header.Get("project_id"); got != "" {
-			t.Errorf("project_id header = %q, want empty (Cardano-side header must not ride on /v2/keys)", got)
+			t.Errorf("project_id header = %q, want empty (Cardano-side header must not ride on /api/v2/keys)", got)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"keys":[]}`))
@@ -556,7 +560,7 @@ func TestDevKeysClient_StripsAPIKeyAndPromotesDevJWT(t *testing.T) {
 
 	// Critical: the original cfg must not be mutated by devKeysClient.
 	// Subsequent config.Save() should write the unchanged state back.
-	if cfg.APIKey != "should-be-stripped" || cfg.UserJWT != "wallet-jwt-should-not-promote" {
+	if cfg.APIKey != "api-key-must-ride" || cfg.UserJWT != "wallet-jwt-must-not-promote" {
 		t.Errorf("devKeysClient mutated source cfg: APIKey=%q UserJWT=%q (want unchanged)", cfg.APIKey, cfg.UserJWT)
 	}
 	// Source SubmitHeaders must remain intact AND retain its original


### PR DESCRIPTION
## Summary

The 0.12.0 release ships `dev keys list|create|delete` with a "single-credential isolation" clone pattern that **strips X-API-Key** from requests to `/api/v2/keys`. That mirrored the existing `apikey.go` pattern for `/v2/apikey/developer/*`. Wrong surface: `/api/v2/keys` requires **both** `X-API-Key` (V2AuthMiddleware app-level auth) **and** `Authorization: Bearer <devJWT>` (developerJWTAuth identity). Sending dev-JWT alone returns 401.

Result: every `dev keys` command on 0.12.0 returns 401 against the live gateway. Discovered in the v2.3.0-rc2 CLI smoke an hour ago.

## Fix

`cmd/andamio/dev_keys.go:devKeysClient` no longer clears `APIKey`. It still promotes `DevJWT` into the `UserJWT` slot (so the wallet/user JWT, if also stored, is overwritten and never leaks). Both `X-API-Key` and `Authorization: Bearer <devJWT>` now ride on the wire.

## Verified live against preprod.api.andamio.io

```
$ /tmp/andamio-test dev keys list --output json
{
  "keys": [
    {
      "id": "8d220419-3c3f-40a9-b010-ac9d8e65159b",
      "name": "andamio-app",
      "environment": "mainnet",
      ...
    }
  ]
}
```

The 0.12.0 binary returns 401 on the same config and same wallet.

## Tests

The previous tests in `dev_keys_test.go` faithfully pinned the wrong contract. They're flipped:

- Fixture's `APIKey` is no longer a tripwire — value renamed to `expected-api-key-on-wire`.
- `assertOnlyDevJWTOnTheWire` → `assertDualCredentialAuthOnTheWire`. The helper now asserts `X-API-Key` equals the configured value.
- `TestDevKeysClient_StripsAPIKeyAndPromotesDevJWT` → `TestDevKeysClient_PreservesAPIKeyAndPromotesDevJWT`, with flipped assertion on `X-API-Key`.
- The wallet/user JWT remains a tripwire — the clone overwrites the `UserJWT` slot with the `DevJWT`, so the wallet JWT is structurally prevented from reaching the wire.

`go test ./...` is green locally.

## Notes for users

`auth login --api-key <key>` is now a stated precondition for `dev keys` commands (it always was, in the gateway's eyes — we just weren't sending it). The Long help on `dev keys` and the package-level comment in `dev_keys.go` are updated.

## Test plan

- [x] All existing `dev_keys` tests pass after the assertion flip
- [x] Full `go test ./...` green
- [x] Locally-built binary verified against `preprod.api.andamio.io` — `dev keys list` returns 200 with the expected envelope
- [ ] After merge: bump CHANGELOG `[Unreleased]` to `[0.12.1] - 2026-05-07`, run `./scripts/release.sh 0.12.1`
- [ ] Re-run Track B end-to-end against preprod with the released 0.12.1 binary

## Separate finding (not blocking this PR)

`dev keys create --environment preprod` against `preprod.api.andamio.io` returns 503 `preprod_routing_disabled`: "this gateway is not configured to proxy Preprod key operations". This is a documented stable error code; likely the cross-env routing config (`CROSS_ENV_PREPROD_GATEWAY_URL`) isn't set on the preprod gateway, or the architecture expects creates to go through `mainnet.api.andamio.io`. Worth a separate gateway-side issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)