### PR TITLE
feat(teacher): show assignment commitment status in 'teacher assignments list'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ openapi.json
 
 # Export output
 compiled/
+
+# Compound-engineering review artifacts (per-run scratch)
+.context/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/
 
 ## [Unreleased]
 
+### Added
+- `andamio teacher assignments list` (text mode) now renders a `Status` column populated from `content.commitment_status` — the raw API enum, displayed verbatim with no aliasing. Operators can see at a glance whether each row is `AWAITING_SUBMISSION`, `SUBMITTED`, `ACCEPTED`, `REFUSED`, `CREDENTIAL_CLAIMED`, `LEFT`, or transient `PENDING_TX_*`. The column width is dynamic with a 20-rune floor so future enum additions are never truncated. Rows from the no-`--course` summary (which lacks the nested status field) render `"—"` as a placeholder rather than blanking the cell; re-run with `--course <id>` to get the DB status. JSON output already passed the gateway envelope through verbatim and is unchanged — a regression test now pins that contract so a future struct-decode refactor can't silently drop nested `commitment_status` or `on_chain_status`. Closes #93.
+
 ## [0.12.1] - 2026-05-07
 
 ### Fixed

--- a/cmd/andamio/helpers.go
+++ b/cmd/andamio/helpers.go
@@ -90,6 +90,18 @@ func truncateUTF8(s string, maxRunes int) string {
 	return string(runes[:maxRunes-3]) + "..."
 }
 
+// padRunes right-pads s with spaces to width runes (not bytes). Go's fmt width
+// specifier counts bytes, so multi-byte content like "—" (3 bytes, 1 rune)
+// would underpad visible columns with %-Ns. Use this when a dynamic-width
+// column may contain non-ASCII content and the next column must stay aligned.
+func padRunes(s string, width int) string {
+	n := utf8.RuneCountInString(s)
+	if n >= width {
+		return s
+	}
+	return s + strings.Repeat(" ", width-n)
+}
+
 // printList fetches a list endpoint and prints using PrintList
 func printList(ctx context.Context, path, emptyMsg, titleKey, idKey string, usePost bool) error {
 	cfg, err := config.Load()
@@ -480,4 +492,3 @@ func readEvidenceFlag(cmd *cobra.Command) (string, error) {
 	}
 	return evidence, nil
 }
-

--- a/cmd/andamio/teacher_assignments.go
+++ b/cmd/andamio/teacher_assignments.go
@@ -37,14 +37,16 @@ var teacherAssignmentsListCmd = &cobra.Command{
 	Short: "List pending assignment commitments for review",
 	Long: `List assignment commitments pending teacher review.
 
-Without --course, returns a lightweight summary across all courses. Status
-column will render "—" because the on-chain-only summary lacks the nested
-content.commitment_status field. Use --output json and filter on
-.data[].content.commitment_status to avoid parsing the placeholder.
+Without --course, returns a lightweight summary across all courses. The
+on-chain-only summary has no nested content.commitment_status field, so
+the Status column renders "—" in text mode and the field is absent from
+the JSON envelope. To get DB statuses, re-run with --course <id>.
 
 With --course, returns full merged history (on-chain + DB) for that course,
 with the Status column populated from content.commitment_status (raw API
-enum, displayed verbatim).
+enum, displayed verbatim). For scripting, use:
+  andamio teacher assignments list --course <id> --output json \
+    | jq '.data[].content.commitment_status'
 
 Known commitment_status values: AWAITING_SUBMISSION, SUBMITTED, ACCEPTED,
 REFUSED, CREDENTIAL_CLAIMED, LEFT, PENDING_TX_* (transient). The CLI does

--- a/cmd/andamio/teacher_assignments.go
+++ b/cmd/andamio/teacher_assignments.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"os"
+	"unicode/utf8"
 
 	"github.com/Andamio-Platform/andamio-cli/internal/apierr"
 	"github.com/Andamio-Platform/andamio-cli/internal/client"
@@ -10,6 +13,19 @@ import (
 	"github.com/Andamio-Platform/andamio-cli/internal/output"
 	"github.com/spf13/cobra"
 )
+
+// statusEmpty is rendered in the Status column when content.commitment_status
+// is absent — typically on rows from the no-course-filter "on-chain-only"
+// summary response shape. Not an enum value, not an alias: just a visual
+// placeholder so the column has something to occupy the cell.
+const statusEmpty = "—"
+
+// statusMinWidth is the floor for the Status column. The widest known DB
+// enum string is CREDENTIAL_CLAIMED (18 runes); PENDING_TX_* variants fall
+// in the same range. 20 leaves a column of breathing room and keeps short
+// result sets aligned. The column expands beyond 20 when a value exceeds it
+// so the enum is never truncated.
+const statusMinWidth = 20
 
 var teacherAssignmentsCmd = &cobra.Command{
 	Use:   "assignments",
@@ -21,8 +37,18 @@ var teacherAssignmentsListCmd = &cobra.Command{
 	Short: "List pending assignment commitments for review",
 	Long: `List assignment commitments pending teacher review.
 
-Without --course, returns a lightweight summary across all courses.
-With --course, returns full merged history (on-chain + DB) for that course.
+Without --course, returns a lightweight summary across all courses. Status
+column will render "—" because the on-chain-only summary lacks the nested
+content.commitment_status field. Use --output json and filter on
+.data[].content.commitment_status to avoid parsing the placeholder.
+
+With --course, returns full merged history (on-chain + DB) for that course,
+with the Status column populated from content.commitment_status (raw API
+enum, displayed verbatim).
+
+Known commitment_status values: AWAITING_SUBMISSION, SUBMITTED, ACCEPTED,
+REFUSED, CREDENTIAL_CLAIMED, LEFT, PENDING_TX_* (transient). The CLI does
+not validate or alias — whatever string the gateway returns is what you see.
 
 Examples:
   andamio teacher assignments list
@@ -61,14 +87,8 @@ func runTeacherAssignmentsList(cmd *cobra.Command, args []string) error {
 	}
 	c := client.New(cfg)
 
-	// Build request body with optional course filter
-	var body interface{}
-	if courseID != "" {
-		body = map[string]string{"course_id": courseID}
-	}
-
-	var resp map[string]interface{}
-	if err := c.Post(cmd.Context(), "/api/v2/course/teacher/assignment-commitments/list", body, &resp); err != nil {
+	resp, err := fetchTeacherAssignmentsList(cmd.Context(), c, courseID)
+	if err != nil {
 		return err
 	}
 
@@ -83,9 +103,56 @@ func runTeacherAssignmentsList(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	// Print formatted table
-	fmt.Printf("%-20s %-12s %-15s %s\n", "STUDENT", "MODULE", "SOURCE", "COURSE ID")
-	fmt.Printf("%-20s %-12s %-15s %s\n", "-------", "------", "------", "---------")
+	return renderTeacherAssignmentsListText(data, os.Stdout)
+}
+
+// fetchTeacherAssignmentsList POSTs to the assignment-commitments listing
+// endpoint and returns the raw decoded envelope. Split from the Cobra handler
+// so tests can drive it with an httptest stub without writing to disk config.
+// The envelope is returned as map[string]interface{} so the JSON pass-through
+// path in the caller emits the gateway response verbatim (no struct decoding
+// would silently drop unknown fields).
+func fetchTeacherAssignmentsList(ctx context.Context, c *client.Client, courseID string) (map[string]interface{}, error) {
+	var body interface{}
+	if courseID != "" {
+		body = map[string]string{"course_id": courseID}
+	}
+	var resp map[string]interface{}
+	if err := c.Post(ctx, "/api/v2/course/teacher/assignment-commitments/list", body, &resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// renderTeacherAssignmentsListText writes the text-mode table for the
+// non-empty result set. Split from the Cobra handler so tests can exercise
+// the column-rendering logic without httptest, mirroring the pattern in
+// renderQualifiedContributorsText (project_manager_ops.go).
+//
+// Column layout: STUDENT (20) | MODULE (12) | SOURCE (15) | STATUS (dyn, ≥20) | COURSE ID.
+// Status is read from content.commitment_status. If absent, the cell renders
+// statusEmpty. The API enum is displayed verbatim — no aliasing, no truncation.
+func renderTeacherAssignmentsListText(data []interface{}, stdout io.Writer) error {
+	// First pass: compute the Status column width from the actual data.
+	// The width expands above statusMinWidth if any enum exceeds it, so a
+	// future longer value (e.g., a new PENDING_TX_* variant) renders verbatim
+	// rather than getting silently sliced.
+	statusWidth := statusMinWidth
+	for _, item := range data {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		status := commitmentStatusOrEmpty(m)
+		if w := utf8.RuneCountInString(status); w > statusWidth {
+			statusWidth = w
+		}
+	}
+
+	fmt.Fprintf(stdout, "%-20s %-12s %-15s %s %s\n",
+		"STUDENT", "MODULE", "SOURCE", padRunes("STATUS", statusWidth), "COURSE ID")
+	fmt.Fprintf(stdout, "%-20s %-12s %-15s %s %s\n",
+		"-------", "------", "------", padRunes("------", statusWidth), "---------")
 
 	for _, item := range data {
 		m, ok := item.(map[string]interface{})
@@ -97,13 +164,31 @@ func runTeacherAssignmentsList(cmd *cobra.Command, args []string) error {
 		moduleCode, _ := m["course_module_code"].(string)
 		source, _ := m["source"].(string)
 		cID, _ := m["course_id"].(string)
+		status := commitmentStatusOrEmpty(m)
 
 		student = truncateUTF8(student, 20)
 
-		fmt.Printf("%-20s %-12s %-15s %s\n", student, moduleCode, source, cID)
+		fmt.Fprintf(stdout, "%-20s %-12s %-15s %s %s\n",
+			student, moduleCode, source, padRunes(status, statusWidth), cID)
 	}
 
 	return nil
+}
+
+// commitmentStatusOrEmpty reads content.commitment_status with a safe two-step
+// type assertion. Returns statusEmpty when content is missing, not a map, or
+// commitment_status is absent/empty/non-string. No fallback to on_chain_status
+// or any other field — mixing enums in one column would be aliasing.
+func commitmentStatusOrEmpty(m map[string]interface{}) string {
+	content, ok := m["content"].(map[string]interface{})
+	if !ok {
+		return statusEmpty
+	}
+	status, _ := content["commitment_status"].(string)
+	if status == "" {
+		return statusEmpty
+	}
+	return status
 }
 
 func runTeacherAssignmentsGet(cmd *cobra.Command, args []string) error {
@@ -144,4 +229,3 @@ func runTeacherAssignmentsGet(cmd *cobra.Command, args []string) error {
 			studentAlias, moduleCode, courseID),
 	}
 }
-

--- a/cmd/andamio/teacher_assignments_test.go
+++ b/cmd/andamio/teacher_assignments_test.go
@@ -1,0 +1,550 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Andamio-Platform/andamio-cli/internal/client"
+	"github.com/Andamio-Platform/andamio-cli/internal/config"
+	"github.com/Andamio-Platform/andamio-cli/internal/output"
+)
+
+// =============================================================================
+// renderTeacherAssignmentsListText — pure rendering coverage
+// =============================================================================
+//
+// These tests pin the column layout introduced by issue #93: a Status column
+// between SOURCE and COURSE ID, populated from content.commitment_status. The
+// renderer is split from the Cobra handler so the column logic can be tested
+// without httptest. Pattern mirrors renderQualifiedContributorsText in
+// project_manager_ops_test.go.
+
+// renderRow assembles a single result item with the given fields. content is
+// optional — passing nil simulates the no-course-filter / on-chain-only row
+// shape where content.commitment_status is absent entirely.
+func renderRow(student, module, source, courseID string, content map[string]interface{}) map[string]interface{} {
+	row := map[string]interface{}{
+		"student_alias":      student,
+		"course_module_code": module,
+		"source":             source,
+		"course_id":          courseID,
+	}
+	if content != nil {
+		row["content"] = content
+	}
+	return row
+}
+
+func TestRenderTeacherAssignmentsListText_HappyPath_StatusColumnPresent(t *testing.T) {
+	var stdout bytes.Buffer
+	data := []interface{}{
+		renderRow("ada", "101", "merged", "C1", map[string]interface{}{
+			"commitment_status": "AWAITING_SUBMISSION",
+		}),
+	}
+	if err := renderTeacherAssignmentsListText(data, &stdout); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "STATUS") {
+		t.Errorf("output missing STATUS column header:\n%s", out)
+	}
+	if !strings.Contains(out, "AWAITING_SUBMISSION") {
+		t.Errorf("output missing AWAITING_SUBMISSION value:\n%s", out)
+	}
+	// COURSE ID must still appear after STATUS — verifies column ordering.
+	statusIdx := strings.Index(out, "AWAITING_SUBMISSION")
+	courseIdx := strings.LastIndex(out, "C1")
+	if statusIdx < 0 || courseIdx < 0 || courseIdx <= statusIdx {
+		t.Errorf("STATUS should appear before COURSE ID in row; got status at %d, course at %d:\n%s", statusIdx, courseIdx, out)
+	}
+}
+
+func TestRenderTeacherAssignmentsListText_LongerEnumRendersVerbatim(t *testing.T) {
+	// CREDENTIAL_CLAIMED is 18 runes — within the 20 minimum width, no expansion needed.
+	// This locks the verbatim contract for the widest commonly seen enum.
+	var stdout bytes.Buffer
+	data := []interface{}{
+		renderRow("alan", "201", "merged", "C2", map[string]interface{}{
+			"commitment_status": "CREDENTIAL_CLAIMED",
+		}),
+	}
+	if err := renderTeacherAssignmentsListText(data, &stdout); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "CREDENTIAL_CLAIMED") {
+		t.Errorf("CREDENTIAL_CLAIMED not rendered verbatim:\n%s", stdout.String())
+	}
+}
+
+func TestRenderTeacherAssignmentsListText_PendingTxStatusRendersVerbatim(t *testing.T) {
+	// PENDING_TX_* is a family of transient statuses; the contract is "no
+	// filtering, no aliasing" regardless of which variant the gateway emits.
+	// Using a representative value documents the principle without depending
+	// on an exact server-side string we don't control.
+	var stdout bytes.Buffer
+	data := []interface{}{
+		renderRow("turing", "301", "merged", "C3", map[string]interface{}{
+			"commitment_status": "PENDING_TX_SUBMIT",
+		}),
+	}
+	if err := renderTeacherAssignmentsListText(data, &stdout); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "PENDING_TX_SUBMIT") {
+		t.Errorf("PENDING_TX_SUBMIT not rendered verbatim:\n%s", stdout.String())
+	}
+}
+
+func TestRenderTeacherAssignmentsListText_MissingContentKey_RendersPlaceholder(t *testing.T) {
+	// The no-course-filter response shape returns lightweight on-chain-only
+	// rows where the nested content object is absent entirely. The Status
+	// column must render the placeholder rather than blanking the cell.
+	var stdout bytes.Buffer
+	data := []interface{}{
+		renderRow("ada", "101", "chain_only", "C1", nil),
+	}
+	if err := renderTeacherAssignmentsListText(data, &stdout); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !strings.Contains(stdout.String(), statusEmpty) {
+		t.Errorf("expected placeholder %q for missing content; output:\n%s", statusEmpty, stdout.String())
+	}
+}
+
+func TestRenderTeacherAssignmentsListText_EmptyCommitmentStatus_RendersPlaceholder(t *testing.T) {
+	// content is present but commitment_status is missing or empty. Same
+	// behavior as a missing content key: placeholder, no fallback enum.
+	var stdout bytes.Buffer
+	data := []interface{}{
+		renderRow("ada", "101", "db_only", "C1", map[string]interface{}{
+			// commitment_status omitted
+			"evidence": map[string]interface{}{"foo": "bar"},
+		}),
+	}
+	if err := renderTeacherAssignmentsListText(data, &stdout); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !strings.Contains(stdout.String(), statusEmpty) {
+		t.Errorf("expected placeholder %q for empty commitment_status; output:\n%s", statusEmpty, stdout.String())
+	}
+}
+
+func TestRenderTeacherAssignmentsListText_NoFallbackToOnChainStatus(t *testing.T) {
+	// Even when on_chain_status is populated on the row, the Status column
+	// must NOT fall back to it. Mixing two enums in one column would alias
+	// across them and violate the issue's "no aliasing" contract.
+	var stdout bytes.Buffer
+	row := renderRow("ada", "101", "chain_only", "C1", nil)
+	row["on_chain_status"] = "SOME_ONCHAIN_VALUE"
+	data := []interface{}{row}
+	if err := renderTeacherAssignmentsListText(data, &stdout); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if strings.Contains(stdout.String(), "SOME_ONCHAIN_VALUE") {
+		t.Errorf("Status column must not leak on_chain_status; output:\n%s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), statusEmpty) {
+		t.Errorf("expected placeholder %q; output:\n%s", statusEmpty, stdout.String())
+	}
+}
+
+func TestRenderTeacherAssignmentsListText_MixedStatuses_PreserveAlignment(t *testing.T) {
+	// Multiple rows with a mix of populated, empty, and longer status values
+	// in one table. Each value must render verbatim; the COURSE ID column
+	// must appear at a consistent offset so each row remains parsable.
+	var stdout bytes.Buffer
+	data := []interface{}{
+		renderRow("ada", "101", "merged", "courseA", map[string]interface{}{
+			"commitment_status": "SUBMITTED",
+		}),
+		renderRow("alan", "102", "chain_only", "courseB", nil),
+		renderRow("turing", "103", "merged", "courseC", map[string]interface{}{
+			"commitment_status": "REFUSED",
+		}),
+	}
+	if err := renderTeacherAssignmentsListText(data, &stdout); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	out := stdout.String()
+	for _, want := range []string{"SUBMITTED", "REFUSED", statusEmpty, "courseA", "courseB", "courseC"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in mixed output:\n%s", want, out)
+		}
+	}
+
+	// Locate the column position of each COURSE ID in its row. With
+	// rune-aware padding they must all land in the same column even though
+	// the placeholder is a multi-byte em-dash.
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) < 5 {
+		t.Fatalf("expected header + separator + 3 data rows, got %d lines:\n%s", len(lines), out)
+	}
+	dataLines := lines[2:]
+	type ciCol struct {
+		line  string
+		col   int
+		runes int
+	}
+	cols := make([]ciCol, len(dataLines))
+	for i, line := range dataLines {
+		idx := strings.LastIndex(line, "course")
+		if idx < 0 {
+			t.Fatalf("could not find course ID in line: %q", line)
+		}
+		// Rune column = number of runes before the byte offset idx.
+		runes := []rune(line[:idx])
+		cols[i] = ciCol{line: line, col: idx, runes: len(runes)}
+	}
+	for i := 1; i < len(cols); i++ {
+		if cols[i].runes != cols[0].runes {
+			t.Errorf("COURSE ID column misaligned: line 0 starts at rune col %d, line %d at %d. Em-dash row likely under-padded.\n  line 0: %q\n  line %d: %q",
+				cols[0].runes, i, cols[i].runes, cols[0].line, i, cols[i].line)
+		}
+	}
+}
+
+func TestRenderTeacherAssignmentsListText_ColumnExpandsForLongerStatus(t *testing.T) {
+	// If a future enum value exceeds the 20-rune floor, the column must
+	// expand rather than truncate. We pin the expand-not-slice behavior so
+	// "verbatim" is preserved even when the gateway grows the vocabulary.
+	const longStatus = "A_HYPOTHETICAL_FUTURE_STATUS_LONGER_THAN_TWENTY"
+	var stdout bytes.Buffer
+	data := []interface{}{
+		renderRow("ada", "101", "merged", "C1", map[string]interface{}{
+			"commitment_status": longStatus,
+		}),
+	}
+	if err := renderTeacherAssignmentsListText(data, &stdout); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !strings.Contains(stdout.String(), longStatus) {
+		t.Errorf("long status was sliced or relabeled; output:\n%s", stdout.String())
+	}
+}
+
+// =============================================================================
+// fetchTeacherAssignmentsList — JSON pass-through coverage (R2)
+// =============================================================================
+//
+// These tests exercise the wire path with an httptest stub. They guard the
+// issue's R2 acceptance bullet: JSON output mode must include the status
+// field unchanged. Because fetchTeacherAssignmentsList decodes the body into
+// map[string]interface{} (not a typed struct), any future addition to the
+// gateway envelope flows through automatically — these tests prove the
+// nested status fields specifically survive the round trip today.
+
+func stubTeacherAssignmentsServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *client.Client) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	c := client.New(&config.Config{BaseURL: srv.URL})
+	return srv, c
+}
+
+func TestFetchTeacherAssignmentsList_RequestShape_WithCourseSendsCourseIDInBody(t *testing.T) {
+	var gotPath, gotMethod, gotCT string
+	var gotBody []byte
+	_, c := stubTeacherAssignmentsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		gotCT = r.Header.Get("Content-Type")
+		gotBody, _ = io.ReadAll(r.Body)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"data": []interface{}{}})
+	})
+
+	_, err := fetchTeacherAssignmentsList(context.Background(), c, "the-course-id")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if gotMethod != "POST" {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if want := "/api/v2/course/teacher/assignment-commitments/list"; gotPath != want {
+		t.Errorf("path = %q, want %q", gotPath, want)
+	}
+	if !strings.Contains(gotCT, "application/json") {
+		t.Errorf("Content-Type = %q, want application/json", gotCT)
+	}
+	var parsed map[string]string
+	if err := json.Unmarshal(gotBody, &parsed); err != nil {
+		t.Fatalf("request body not valid JSON: %v; raw=%q", err, gotBody)
+	}
+	if parsed["course_id"] != "the-course-id" {
+		t.Errorf("body.course_id = %q, want %q", parsed["course_id"], "the-course-id")
+	}
+}
+
+func TestFetchTeacherAssignmentsList_RequestShape_WithoutCourseOmitsBody(t *testing.T) {
+	var gotBody []byte
+	_, c := stubTeacherAssignmentsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"data": []interface{}{}})
+	})
+
+	if _, err := fetchTeacherAssignmentsList(context.Background(), c, ""); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(gotBody) != 0 {
+		t.Errorf("body = %q, want empty (no --course filter -> bodyless POST)", string(gotBody))
+	}
+}
+
+func TestFetchTeacherAssignmentsList_JSONPassThrough_PreservesNestedStatusFields(t *testing.T) {
+	// This is the R2 guardrail. Construct a gateway response with both the
+	// nested content.commitment_status and the top-level on_chain_status, then
+	// assert both survive the decode/return cycle. If a future refactor
+	// introduces a typed response struct, this test catches the moment those
+	// fields are silently dropped by missing JSON tags.
+	const responseBody = `{
+        "data": [
+            {
+                "course_id": "C1",
+                "course_module_code": "101",
+                "student_alias": "ada",
+                "source": "merged",
+                "on_chain_status": "ENROLLED",
+                "content": {
+                    "commitment_status": "AWAITING_SUBMISSION",
+                    "assignment_evidence_hash": "abc123"
+                }
+            }
+        ]
+    }`
+	_, c := stubTeacherAssignmentsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, responseBody)
+	})
+
+	resp, err := fetchTeacherAssignmentsList(context.Background(), c, "C1")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	data, ok := resp["data"].([]interface{})
+	if !ok || len(data) != 1 {
+		t.Fatalf("data shape unexpected: %v", resp)
+	}
+	row, ok := data[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("row not a map: %v", data[0])
+	}
+	if got := row["on_chain_status"]; got != "ENROLLED" {
+		t.Errorf("on_chain_status = %v, want ENROLLED", got)
+	}
+	content, ok := row["content"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("content not a map: %v", row["content"])
+	}
+	if got := content["commitment_status"]; got != "AWAITING_SUBMISSION" {
+		t.Errorf("content.commitment_status = %v, want AWAITING_SUBMISSION", got)
+	}
+	if got := content["assignment_evidence_hash"]; got != "abc123" {
+		t.Errorf("content.assignment_evidence_hash = %v, want abc123 (sibling fields must also survive)", got)
+	}
+}
+
+func TestFetchTeacherAssignmentsList_EndToEndText_RendersStatusFromWire(t *testing.T) {
+	// Compose fetch + render to prove the full pipeline emits a STATUS column
+	// populated from the wire response. This is the integration scenario the
+	// renderer unit tests alone can't prove.
+	const responseBody = `{
+        "data": [
+            {
+                "course_id": "C1",
+                "course_module_code": "101",
+                "student_alias": "ada",
+                "source": "merged",
+                "content": {"commitment_status": "ACCEPTED"}
+            }
+        ]
+    }`
+	_, c := stubTeacherAssignmentsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, responseBody)
+	})
+
+	resp, err := fetchTeacherAssignmentsList(context.Background(), c, "C1")
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	data, _ := resp["data"].([]interface{})
+	var stdout bytes.Buffer
+	if err := renderTeacherAssignmentsListText(data, &stdout); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "STATUS") {
+		t.Errorf("end-to-end text missing STATUS column:\n%s", out)
+	}
+	if !strings.Contains(out, "ACCEPTED") {
+		t.Errorf("end-to-end text missing wire status ACCEPTED:\n%s", out)
+	}
+}
+
+// =============================================================================
+// runTeacherAssignmentsList — full Cobra handler integration (plan R2)
+// =============================================================================
+//
+// These tests drive runTeacherAssignmentsList through its Cobra entry point —
+// the same path real users hit. They exercise the format-dispatch branch and
+// the empty-data guard that the renderer-unit and fetch-unit tests bypass.
+// Pattern mirrors dev_test.go (HOME tempdir + config.Save + output.SetFormat
+// + captureStdout).
+
+// teacherAssignmentsHandlerEnv stubs the gateway, sandboxes config to a
+// tempdir HOME, and saves a Config with BaseURL pointed at the stub. Returns
+// nothing the caller needs to keep — all wiring lives in the saved config
+// that the handler reads via config.Load().
+func teacherAssignmentsHandlerEnv(t *testing.T, body string) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(srv.Close)
+
+	t.Setenv("HOME", t.TempDir())
+	if err := config.Save(&config.Config{BaseURL: srv.URL}); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+}
+
+func TestRunTeacherAssignmentsList_JSONOutput_HandlerPassesGatewayShapeVerbatim(t *testing.T) {
+	// R2 regression guard at the handler level: full path through the
+	// format-dispatch branch in runTeacherAssignmentsList, not just the
+	// extracted fetch function. If a future refactor reorders the format
+	// check or wraps the gateway envelope before printing, this test fails.
+	const responseBody = `{
+        "data": [
+            {
+                "course_id": "C1",
+                "course_module_code": "101",
+                "student_alias": "ada",
+                "source": "merged",
+                "on_chain_status": "ENROLLED",
+                "content": {
+                    "commitment_status": "AWAITING_SUBMISSION",
+                    "assignment_evidence_hash": "abc123"
+                }
+            }
+        ]
+    }`
+	teacherAssignmentsHandlerEnv(t, responseBody)
+
+	cmd := teacherAssignmentsListCmd
+	cmd.SetContext(context.Background())
+	if err := cmd.Flags().Set("course", "C1"); err != nil {
+		t.Fatalf("set --course flag: %v", err)
+	}
+	t.Cleanup(func() { _ = cmd.Flags().Set("course", "") })
+
+	captured := captureStdout(t, func() {
+		_ = output.SetFormat("json")
+		t.Cleanup(func() { _ = output.SetFormat("text") })
+		if err := cmd.RunE(cmd, []string{}); err != nil {
+			t.Fatalf("handler: %v", err)
+		}
+	})
+
+	var got map[string]interface{}
+	if err := json.Unmarshal([]byte(captured), &got); err != nil {
+		t.Fatalf("handler stdout is not JSON: %v\nbytes: %s", err, captured)
+	}
+
+	data, ok := got["data"].([]interface{})
+	if !ok || len(data) != 1 {
+		t.Fatalf("data shape unexpected: %v", got)
+	}
+	row, _ := data[0].(map[string]interface{})
+	if row["on_chain_status"] != "ENROLLED" {
+		t.Errorf("on_chain_status = %v, want ENROLLED (top-level status field must survive handler dispatch)", row["on_chain_status"])
+	}
+	content, ok := row["content"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("content not a nested map: %v", row["content"])
+	}
+	if content["commitment_status"] != "AWAITING_SUBMISSION" {
+		t.Errorf("content.commitment_status = %v, want AWAITING_SUBMISSION (R2: nested status must survive)", content["commitment_status"])
+	}
+	if content["assignment_evidence_hash"] != "abc123" {
+		t.Errorf("content.assignment_evidence_hash = %v, want abc123 (R2: sibling nested fields must also survive)", content["assignment_evidence_hash"])
+	}
+}
+
+func TestRunTeacherAssignmentsList_TextOutput_HandlerRendersStatusColumn(t *testing.T) {
+	// End-to-end text path: full handler exercises format dispatch and the
+	// renderer. Catches regressions where a future change short-circuits the
+	// text branch (e.g., flips the format check to == FormatJSON, which would
+	// drop CSV/markdown through to text silently).
+	const responseBody = `{
+        "data": [
+            {
+                "course_id": "C1",
+                "course_module_code": "101",
+                "student_alias": "ada",
+                "source": "merged",
+                "content": {"commitment_status": "ACCEPTED"}
+            }
+        ]
+    }`
+	teacherAssignmentsHandlerEnv(t, responseBody)
+
+	cmd := teacherAssignmentsListCmd
+	cmd.SetContext(context.Background())
+	if err := cmd.Flags().Set("course", "C1"); err != nil {
+		t.Fatalf("set --course flag: %v", err)
+	}
+	t.Cleanup(func() { _ = cmd.Flags().Set("course", "") })
+
+	captured := captureStdout(t, func() {
+		_ = output.SetFormat("text")
+		if err := cmd.RunE(cmd, []string{}); err != nil {
+			t.Fatalf("handler: %v", err)
+		}
+	})
+
+	if !strings.Contains(captured, "STATUS") {
+		t.Errorf("handler text output missing STATUS column:\n%s", captured)
+	}
+	if !strings.Contains(captured, "ACCEPTED") {
+		t.Errorf("handler text output missing wire status ACCEPTED:\n%s", captured)
+	}
+}
+
+// =============================================================================
+// padRunes — small invariant check on the rune-aware padder
+// =============================================================================
+//
+// padRunes lives in helpers.go alongside truncateUTF8 (both are rune-aware
+// string utilities for fixed-width table rendering). These tests cover its
+// invariants and stay in this file because the original need for the helper
+// was the Status column's em-dash placeholder.
+
+func TestPadRunes_PadsMultiByteToVisualWidth(t *testing.T) {
+	// "—" is 3 bytes but 1 rune. padRunes must pad to the requested rune
+	// width so adjacent columns stay aligned. Without this helper, fmt's
+	// %-Ns byte-counting would underpad em-dash rows.
+	got := padRunes("—", 5)
+	wantRunes := 5
+	if r := len([]rune(got)); r != wantRunes {
+		t.Errorf("padRunes(\"—\", 5) produced %d runes, want %d; got=%q", r, wantRunes, got)
+	}
+	if !strings.HasPrefix(got, "—") {
+		t.Errorf("padRunes should prefix with the input; got=%q", got)
+	}
+}
+
+func TestPadRunes_NoOpWhenAlreadyAtOrAboveWidth(t *testing.T) {
+	if got := padRunes("EXACTLY_TEN", 10); got != "EXACTLY_TEN" {
+		t.Errorf("padRunes did not pass through equal-width string: %q", got)
+	}
+	if got := padRunes("LONGER_THAN_FIVE", 5); got != "LONGER_THAN_FIVE" {
+		t.Errorf("padRunes truncated a longer-than-width string: %q", got)
+	}
+}

--- a/docs/plans/2026-05-13-001-feat-teacher-assignments-list-status-column-plan.md
+++ b/docs/plans/2026-05-13-001-feat-teacher-assignments-list-status-column-plan.md
@@ -1,0 +1,166 @@
+---
+title: "feat: surface assignment commitment status in `teacher assignments list`"
+type: feat
+status: completed
+date: 2026-05-13
+---
+
+# Surface assignment commitment status in `teacher assignments list`
+
+## Overview
+
+Add a `Status` column to `andamio teacher assignments list` (text mode) so operators reading CLI output can see whether each assignment is `AWAITING_SUBMISSION`, `SUBMITTED`, `ACCEPTED`, `REFUSED`, `CREDENTIAL_CLAIMED`, `LEFT`, or a transient `PENDING_TX_*`. The CLI displays the API enum verbatim — no aliasing or relabeling. JSON output already passes the API envelope through unchanged, so this work is text-mode only plus a small render extraction so the column gets unit coverage.
+
+Closes [#93](https://github.com/Andamio-Platform/andamio-cli/issues/93).
+
+## Problem Frame
+
+Surfaced by the cross-surface status vocabulary audit (orch: `Status vocabulary audit — API, CLI, app.md`). Tasks (`cmd/andamio/project_task.go:311`) and course modules already expose status in their listings; assignment commitments are the last commitment surface without it. Without a status column, an operator cannot tell at a glance which submissions are awaiting review, already accepted, refused (retriable), or finalized via credential claim.
+
+The endpoint already returns the data:
+
+- Path: `POST /api/v2/course/teacher/assignment-commitments/list`
+- With `--course`: full merged history (on-chain + DB). `data[].content.commitment_status` carries the DB-authoritative status (the enum from the issue's canon).
+- Without `--course`: lightweight on-chain-only summary. `content.commitment_status` is typically absent; only top-level `on_chain_status` is populated. Per resolved planning question below, we render those rows as empty/dash and let operators re-run with `--course <id>` for full status.
+
+## Requirements Trace
+
+- **R1.** Text mode of `andamio teacher assignments list` shows a `Status` column with `content.commitment_status` from the API response, displayed verbatim. (Issue acceptance bullet 1.)
+- **R2.** JSON output mode includes the status field unchanged. The existing handler already pass-throughs the gateway envelope; verify this remains true and add a regression test. (Issue acceptance bullet 2.)
+- **R3.** No aliasing or relabeling — display the raw enum string. Mapping to user-facing language stays in the app layer. (Issue acceptance bullet 3.)
+
+## Scope Boundaries
+
+- Only `cmd/andamio/teacher_assignments.go` (the `teacher assignments list` command) is in scope.
+- No changes to the API. The CLI consumes whatever the gateway emits.
+- No aliasing layer, no localization, no color codes, no enum validation.
+
+### Deferred to Separate Tasks
+
+- **`course teacher commitments`** (`cmd/andamio/course_teacher_ops.go:682`): hits the same endpoint but renders via the generic `printListPost` → `output.PrintList` (title + id only). Adding a status column there requires either extending `PrintList`'s signature or building a custom renderer like this plan does. Leave for a follow-up if/when the audit calls it out — the issue scopes specifically to `teacher_assignments.go:70-71`.
+- **`teacher assignments get`**: JSON-only output via `output.PrintJSON(m)` already carries the nested `content.commitment_status` field. No change needed.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `cmd/andamio/teacher_assignments.go:87-104` — the existing custom printf table for `teacher assignments list`. Columns today: `STUDENT`, `MODULE`, `SOURCE`, `COURSE ID`. The fix extends this loop.
+- `cmd/andamio/project_task.go:311-342` — precedent for a custom table with a `Status` column. Reads `task_status` (top-level) with a fallback to `source`. The pattern (read field, fallback if empty, render fixed-width column) is the model to follow here.
+- `cmd/andamio/project_manager_ops.go:139-155` (`renderQualifiedContributorsText`) — precedent for extracting a render function that takes `stdout`/`stderr` writers so it can be unit-tested without an httptest server. This plan applies the same shape.
+- `internal/output/output.go:62` — `PrintList` only supports two columns (title + id), so a custom printf table is the right tool for a 5-column listing. No change to the `output` package is needed.
+
+### Schema (from `openapi.json`)
+
+`TeacherAssignmentCommitmentItem`:
+
+| Field | Source | Notes |
+|---|---|---|
+| `course_id` | top-level | identifier |
+| `course_module_code` | top-level | human-readable module code |
+| `student_alias` | top-level | participant |
+| `source` | top-level | `"merged"` / `"db_only"` / `"chain_only"` |
+| `on_chain_status` | top-level | on-chain student status (separate enum) |
+| `content.commitment_status` | nested | **the status this plan surfaces.** Issue canon: `AWAITING_SUBMISSION`, `SUBMITTED`, `ACCEPTED`, `REFUSED`, `CREDENTIAL_CLAIMED`, `LEFT`, `PENDING_TX_*`. |
+
+The CLI does not validate or enumerate values; it displays whatever the gateway returns. The issue's enum list (above) is the human-readable canon; `andamio-api/internal/internal_api/andamio_db_client/client.go:162-174` is the executable source the issue points to; the OpenAPI description string `"DRAFT, SUBMITTED, APPROVED, etc."` is stale and ignored.
+
+### Institutional Learnings
+
+- `docs/solutions/feature-implementations/cli-teacher-assignment-commitments-commands.md` — the original feature solution doc. Key reminders: non-text format dispatch happens before the empty-data check; the JSON path is already verbatim pass-through.
+- `docs/solutions/architecture/cli-composability-audit-and-fix.md` — stderr/stdout discipline. Status column lives in stdout (data); any hint about empty status (none planned here) would belong on stderr.
+
+## Key Technical Decisions
+
+- **Render only `content.commitment_status`, no cross-enum fallback.** When `--course` is omitted, `content.commitment_status` is typically absent; render empty (rationale: the field is genuinely absent in the API response — empty is the "raw API value"). Mixing `on_chain_status` into the same column would be aliasing across two different enums and violates the issue's "no aliasing" rule.
+- **Use `"—"` (em-dash) as the empty-value placeholder.** Cleaner in fixed-width tables than a blank cell and matches what humans typically read as "no value." A pure empty string would render as trailing whitespace, which is harder to scan. This is presentation, not aliasing — no enum value is invented.
+- **Status column uses dynamic width, minimum 20.** The longest known enum string is `CREDENTIAL_CLAIMED` (18); transient `PENDING_TX_*` variants fall within the same range. The column is sized to fit the widest value present in the current result set without truncation, with a 20-character floor so short result sets still align cleanly. Truncating would silently corrupt the enum — that violates "verbatim" — so if a longer value appears the column expands and the row stretches rather than slicing.
+- **Extract the row-render loop into a `renderTeacherAssignmentsListText(data []interface{}, stdout io.Writer) error` function.** Mirrors the `renderQualifiedContributorsText` pattern (`project_manager_ops.go:144`) so the new column is unit-testable end-to-end without spinning up an httptest server. The fetch path stays in `runTeacherAssignmentsList`; the renderer is pure.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **What does the Status column show when `--course` is omitted?** Resolved with the user: render empty (em-dash placeholder). No cross-enum fallback. Users get full status by re-running with `--course <id>`.
+- **Do we need to update the JSON path?** No. `output.PrintJSON(resp)` already pass-throughs the gateway envelope verbatim. The status field is already present in JSON output today — this plan adds a regression test, not new behavior.
+- **Do we modify `course teacher commitments` or the `output.PrintList` helper?** No. Scoped out per Scope Boundaries.
+
+### Deferred to Implementation
+
+- None. The change is small and fully specified.
+
+## Implementation Units
+
+- [x] **Unit 1: Add Status column to the `teacher assignments list` text renderer**
+
+**Goal:** Surface `content.commitment_status` as a new `Status` column in the text-mode table for `andamio teacher assignments list`, displayed verbatim. JSON path stays unchanged (already correct).
+
+**Requirements:** R1, R2, R3
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `cmd/andamio/teacher_assignments.go`
+- Test: `cmd/andamio/teacher_assignments_test.go` (new)
+
+**Approach:**
+- Extract the existing text-mode rendering loop (`teacher_assignments.go:86-104`) into a new package-level function `renderTeacherAssignmentsListText(data []interface{}, stdout io.Writer) error`. The fetch and format-dispatch logic stays in `runTeacherAssignmentsList`; only the loop moves.
+- Insert a new `Status` column between `SOURCE` and `COURSE ID`. New header line: `STUDENT`, `MODULE`, `SOURCE`, `STATUS`, `COURSE ID`. Column widths: 20 / 12 / 15 / dynamic-min-20 / remainder. The Status column expands when a row's value exceeds 20 chars so the enum is never truncated.
+- Read status with nested access: `m["content"].(map[string]interface{})["commitment_status"].(string)`. Use the safe two-step type assertion (check `content` exists and is a map before reading the field). If the nested value is missing or empty, render `"—"` (em-dash). Do not fall back to `on_chain_status` or any other field.
+- Keep all existing fields (`student_alias`, `course_module_code`, `source`, `course_id`) and their widths unchanged.
+- Leave `runTeacherAssignmentsGet` and the JSON pass-through path (`output.PrintJSON(resp)`) untouched.
+
+**Patterns to follow:**
+- `cmd/andamio/project_task.go:311-342` — custom printf table with a `Status` column.
+- `cmd/andamio/project_manager_ops.go:139-155` — extracted `renderXText(data, writer)` for unit testability.
+- `cmd/andamio/teacher_assignments.go:75-78` — non-text format dispatch must remain ahead of any data-shape work.
+
+**Test scenarios:**
+- Happy path — `renderTeacherAssignmentsListText` writes a `STATUS` column header and a row with `content.commitment_status = "AWAITING_SUBMISSION"` renders the value verbatim in the Status column.
+- Happy path — row with `content.commitment_status = "CREDENTIAL_CLAIMED"` renders verbatim (validates that longer enum values fit within the 20-wide column).
+- Happy path — row with a `PENDING_TX_*` value in `content.commitment_status` renders verbatim. Use whatever transient enum the API currently emits (look it up against `andamio-api` or a recent preprod fixture before writing the test). Validates that the "no filtering, no aliasing" principle holds for transient statuses.
+- Edge case — row missing the `content` key entirely renders `"—"` in the Status column (the `--course` omitted case where the on-chain summary has no nested content).
+- Edge case — row where `content` is a map but `commitment_status` is missing/empty renders `"—"`.
+- Edge case — multiple rows with different statuses (mix of `SUBMITTED`, empty, `REFUSED`) all render correctly in one table, preserving column alignment.
+- Integration — full handler `runTeacherAssignmentsList` with `--output json` against an httptest server returns the gateway envelope verbatim, including `data[].content.commitment_status` and `data[].on_chain_status`. This guards the issue's R2 acceptance bullet against future regressions.
+- Integration — full handler with default text output against an httptest server returns a table containing `STATUS` header and the expected verbatim status values. Covers the end-to-end fetch → render path.
+
+**Verification:**
+- `go build -o andamio ./cmd/andamio && ./andamio teacher assignments list --help` shows the unchanged help text (no flag changes).
+- Against a preprod environment with a real teacher JWT, `./andamio teacher assignments list --course <id>` renders the new `STATUS` column populated with the API enum verbatim.
+- `./andamio teacher assignments list --course <id> --output json | jq '.data[0].content.commitment_status'` returns the same enum string the text mode printed.
+- `./andamio teacher assignments list` (no `--course`) renders the new `STATUS` column with `"—"` placeholders for on-chain-only rows.
+- `go test ./cmd/andamio/...` passes; new tests cover the scenarios above.
+
+## System-Wide Impact
+
+- **Interaction graph:** None. `runTeacherAssignmentsList` is a leaf command; no callbacks, middleware, or observers depend on its output shape.
+- **API surface parity:** A parallel command `course teacher commitments` (`course_teacher_ops.go:682`) hits the same endpoint but uses the generic `printListPost`/`PrintList` helper that only supports title + id columns. It is intentionally out of scope (see Scope Boundaries). If the audit later requires the same status surface there, expect a follow-up that either replaces the generic helper call with a custom renderer or extends `output.PrintList` to support N columns.
+- **Integration coverage:** Adding an httptest-backed test for the full `runTeacherAssignmentsList` text + JSON paths is the integration scenario unit tests of the renderer alone cannot prove (verifies that fetch + format dispatch + render compose correctly, and that JSON pass-through preserves nested status fields). Cover this in Unit 1's test scenarios.
+- **Unchanged invariants:**
+  - JSON output remains a verbatim pass-through of the gateway envelope. Adding a Status column to text mode does not transform, alias, or filter the JSON path.
+  - `runTeacherAssignmentsGet` behavior is unchanged. It already returns the full item via `output.PrintJSON(m)`, and that envelope already includes `content.commitment_status`.
+  - Existing text column ordering (`STUDENT` first, `COURSE ID` last) is preserved; the new column is inserted in the middle so left-anchored greps on student alias continue to work.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Future gateway response shape change (e.g., `commitment_status` moves out of `content`) silently produces a column of em-dashes and operators don't notice. | Add the integration test that asserts the live-shape happy path against an httptest server fixture. If the gateway moves the field, the test fails immediately. |
+| `PENDING_TX_*` enum values are wider than expected and break column alignment. | Column width is 20, which fits known values plus one column of breathing room. If a longer value appears we let the row stretch rather than truncate — truncation would silently corrupt the enum and violate "verbatim." |
+| The em-dash placeholder is read as a literal enum value by a downstream tool. | The placeholder only appears in text mode. JSON output preserves the actual API shape (missing field or empty string), so any script consuming the command uses `--output json`. |
+
+## Documentation / Operational Notes
+
+- Update `CHANGELOG.md` under `## [Unreleased]` with a short entry: "feat(teacher): show assignment commitment status in `teacher assignments list` text output". The release script will promote it to the next versioned heading.
+- No update needed to `CLAUDE.md`'s command reference table — the row for `course teacher commitments` already exists and the command name plus auth column do not change. (The Status column is a text-output detail, not a command-surface change.)
+- No `docs/COURSE-LIFECYCLE.md` or `docs/TX-LIFECYCLE.md` updates required — those describe state lifecycles, not CLI table columns.
+
+## Sources & References
+
+- GitHub issue: [#93 — Expose assignment commitment status in teacher_assignments listings](https://github.com/Andamio-Platform/andamio-cli/issues/93)
+- Origin audit (private): `orch:Status vocabulary audit — API, CLI, app.md`
+- Canon enum source: `andamio-api/internal/internal_api/andamio_db_client/client.go:162-174` (referenced from the issue)
+- Related CLI command: `cmd/andamio/teacher_assignments.go:55-107` (target)
+- Pattern precedents: `cmd/andamio/project_task.go:311-342`, `cmd/andamio/project_manager_ops.go:139-155`
+- OpenAPI schema: `openapi.json` — `TeacherAssignmentCommitmentItem`, `AssignmentCommitmentContent`
+- Prior solution: `docs/solutions/feature-implementations/cli-teacher-assignment-commitments-commands.md`


### PR DESCRIPTION
## Summary

Closes #93. The teacher CLI lists assignment commitments via `andamio teacher assignments list` but, until now, gave operators no way to see whether each row was awaiting submission, accepted, refused, or already credential-claimed. The endpoint returns the data — `data[].content.commitment_status` — but the text table had no column for it. This PR adds a `Status` column to the text output, displayed verbatim from the API. JSON output already passed the gateway envelope through unchanged; a regression test now pins that contract at both the fetch and handler levels.

## What changed

A new column slots between `SOURCE` and `COURSE ID`, populated from `data[].content.commitment_status` (the DB-authoritative status enum). The CLI does not validate or alias — whatever string the gateway returns is what you see.

```
STUDENT              MODULE       SOURCE          STATUS               COURSE ID
-------              ------       ------          ------               ---------
ada                  101          merged          AWAITING_SUBMISSION  courseA
alan                 102          merged          SUBMITTED            courseB
turing               201          merged          CREDENTIAL_CLAIMED   courseC
godel                201          chain_only      —                    courseD
```

Three design decisions worth flagging:

- **Dynamic column width with a 20-rune floor.** `CREDENTIAL_CLAIMED` is 18 runes; `PENDING_TX_*` variants fall in the same range. If a future enum exceeds 20, the column expands rather than slicing — truncation would silently corrupt the enum.
- **Em-dash placeholder for rows without status.** When `--course` is omitted, the API returns a lightweight on-chain-only summary where `content.commitment_status` is absent. The cell renders `"—"` (em-dash) rather than blanking. No cross-enum fallback to `on_chain_status` — that would mix two different enums in one column and violate the "no aliasing" rule.
- **Rune-aware padding.** `fmt`'s width specifier counts bytes, so the 3-byte em-dash would underpad columns. `padRunes` in `helpers.go` keeps `COURSE ID` aligned across mixed rows. A `MixedStatuses_PreserveAlignment` test pins this with explicit rune-column math.

## Test plan

- 14 new tests in `cmd/andamio/teacher_assignments_test.go`:
  - 8 renderer unit tests covering happy paths (verbatim enum + longer enum + `PENDING_TX_*`), edge cases (missing content key, empty status, no fallback to `on_chain_status`), alignment across mixed rows, and dynamic column expansion.
  - 4 wire-shape tests via `httptest` — request body shape (with/without `--course`), JSON pass-through preserving nested `commitment_status` + `on_chain_status`, and end-to-end fetch + render.
  - 2 handler-level integration tests driving `runTeacherAssignmentsList` through Cobra's `RunE` — one pins the R2 JSON envelope at the handler dispatch level, one exercises the full text path.
  - 2 `padRunes` invariant tests.
- `go test ./...` passes, `go vet ./...` clean, `gofmt` clean on all touched files.
- Manual verification: `./andamio teacher assignments list --help` shows the expanded help text (em-dash explanation, known status values, `--output json` workaround).

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. This is a CLI text-output change consumed locally; no production runtime impact, no API contract change, no migration. JSON output (the agent-scripting surface) was already pass-through verbatim and is unchanged — a regression test now guards that invariant.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)