### PR TITLE
fix(import): derive app host correctly on mainnet for image uploads (#117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/
 
 ## [Unreleased]
 
+### Fixed
+- `andamio course import` / `import-all` image uploads now derive the correct app host on **mainnet**. `uploadImage` previously did a plain `.api.` → `.app.` substitution, which no-ops on the mainnet base URL `https://api.andamio.io` (no subdomain prefix) and POSTed images to the API gateway `https://api.andamio.io/api/upload` → **404**. Lesson text imported fine but every image failed and lessons were stored with unresolved `assets/<file>` references (broken images on-platform). Hit during the Cardano Go PBL mainnet import — 11 images across modules 099/100/102/202. Re-import picks up the images once a fixed binary is installed. The 0.13.2 fix corrected the same bug in `buildAuthURL` (browser auth); this generalizes that dual-host logic into a single shared `appURLFromBase` helper and routes all three derivation sites through it. Regression tests `TestUploadURLDerivation`, `TestAppURLFromBase` pin both host shapes. Closes #117.
+- `andamio dev login` (browser flow) Origin allow-list (`deriveAppOrigin`) carried the same latent single-`.api.`-replace bug and would have misderived the allowed Origin to the API host on mainnet, rejecting the legitimate app-origin callback POST. Now routes through `appURLFromBase`; the empty/unparseable fail-closed contract is preserved. Regression test `TestDeriveAppOrigin` covers mainnet, preprod, and both fail-closed paths.
+
 ## [0.13.2] - 2026-06-04
 
 ### Fixed

--- a/cmd/andamio/course_import.go
+++ b/cmd/andamio/course_import.go
@@ -1412,9 +1412,10 @@ func updateModuleContent(ctx context.Context, c *client.Client, courseID string,
 // uploadImage uploads a single image file to the app's /api/upload endpoint.
 // Returns the public CDN URL on success.
 func uploadImage(cfg *config.Config, filePath string) (string, error) {
-	// Derive app URL from API URL (same pattern as user.go OAuth flow)
-	appURL := strings.Replace(cfg.BaseURL, ".api.", ".app.", 1)
-	uploadURL := appURL + "/api/upload"
+	// Derive app URL from API URL via the shared helper, which handles both
+	// host shapes (preprod's `.api.` subdomain and mainnet's bare `//api.`).
+	// A plain `.api.` replace no-ops on mainnet and 404s the upload (issue #117).
+	uploadURL := appURLFromBase(cfg.BaseURL) + "/api/upload"
 
 	// Read file
 	fileData, err := os.ReadFile(filePath)

--- a/cmd/andamio/course_import_test.go
+++ b/cmd/andamio/course_import_test.go
@@ -800,3 +800,25 @@ func TestCheckSilentSLTFailure(t *testing.T) {
 		})
 	}
 }
+
+// TestUploadURLDerivation guards the host derivation for image uploads. The
+// upload must target the app host, not the API gateway, on both preprod and
+// mainnet base URLs. A regression here resurfaces issue #117 (mainnet 404).
+func TestUploadURLDerivation(t *testing.T) {
+	cases := []struct {
+		name    string
+		baseURL string
+		want    string
+	}{
+		{"mainnet", "https://api.andamio.io", "https://app.andamio.io/api/upload"},
+		{"preprod", "https://preprod.api.andamio.io", "https://preprod.app.andamio.io/api/upload"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := appURLFromBase(tc.baseURL) + "/api/upload"
+			if got != tc.want {
+				t.Errorf("upload URL for base %q = %q, want %q", tc.baseURL, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/andamio/dev.go
+++ b/cmd/andamio/dev.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/Andamio-Platform/andamio-cli/internal/apierr"
@@ -36,19 +35,19 @@ func shutdownServer(s *http.Server) {
 }
 
 // deriveAppOrigin returns the scheme+host portion of the Andamio app URL
-// derived from a configured API base URL via the same `.api.` → `.app.`
-// substitution that buildAuthURL uses. Returns the empty string for an
-// unparseable BaseURL — callers that depend on the origin (CORS preflight,
-// Origin allow-list) should treat an empty result as "no browser will be
-// allowed to POST" rather than "any browser allowed", which is the safe
-// failure mode. A separate plan (#108) covers BaseURL validation; this
-// helper does not gate that — it just produces a sensible value when
-// BaseURL is well-formed.
+// derived from a configured API base URL via the shared appURLFromBase helper,
+// which handles both the preprod `.api.` and mainnet bare `//api.` host shapes.
+// Returns the empty string for an unparseable BaseURL — callers that depend on
+// the origin (CORS preflight, Origin allow-list) should treat an empty result
+// as "no browser will be allowed to POST" rather than "any browser allowed",
+// which is the safe failure mode. A separate plan (#108) covers BaseURL
+// validation; this helper does not gate that — it just produces a sensible
+// value when BaseURL is well-formed.
 func deriveAppOrigin(baseURL string) string {
 	if baseURL == "" {
 		return ""
 	}
-	appURL := strings.Replace(baseURL, ".api.", ".app.", 1)
+	appURL := appURLFromBase(baseURL)
 	u, err := url.Parse(appURL)
 	if err != nil || u.Scheme == "" || u.Host == "" {
 		return ""

--- a/cmd/andamio/dev_test.go
+++ b/cmd/andamio/dev_test.go
@@ -2533,3 +2533,29 @@ func TestRunDevLogin_SkeyExplicitEmpty_RoutesToHeadless(t *testing.T) {
 		t.Errorf("err = %q, want partial-flag error naming missing --alias and --address", err.Error())
 	}
 }
+
+// TestDeriveAppOrigin guards the dev-login Origin allow-list derivation. The
+// origin must resolve to the app host on both preprod and mainnet, and must
+// fail closed (empty) on empty/unparseable input so a misderived origin can
+// never widen the CORS allow-list. Mainnet was previously misderived to the
+// API host (issue #117's sibling bug).
+func TestDeriveAppOrigin(t *testing.T) {
+	cases := []struct {
+		name    string
+		baseURL string
+		want    string
+	}{
+		{"mainnet", "https://api.andamio.io", "https://app.andamio.io"},
+		{"preprod", "https://preprod.api.andamio.io", "https://preprod.app.andamio.io"},
+		{"empty fails closed", "", ""},
+		{"unparseable fails closed", "://nope", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := deriveAppOrigin(tc.baseURL)
+			if got != tc.want {
+				t.Errorf("deriveAppOrigin(%q) = %q, want %q", tc.baseURL, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/andamio/user.go
+++ b/cmd/andamio/user.go
@@ -630,23 +630,32 @@ func getInt(m map[string]interface{}, key string) int {
 // this compiles cleanly even though user.go itself does not reference it.
 var openURL = browser.OpenURL
 
+// appURLFromBase converts a configured API base URL into the corresponding
+// Andamio app base URL by swapping the `api` host segment for `app`. The host
+// has two real shapes and no single string replace covers both:
+//
+//	https://preprod.api.andamio.io -> https://preprod.app.andamio.io  (.api. form)
+//	https://api.andamio.io         -> https://app.andamio.io          (//api. form)
+//
+// A plain `.api.` replace no-ops on production (`api.andamio.io` contains
+// `//api.`, not `.api.`), which silently pointed image uploads and the dev-login
+// Origin allow-list at the API gateway on mainnet (issue #117). This is the
+// single source of truth for the swap — buildAuthURL, uploadImage, and
+// deriveAppOrigin all route through it. Empty input returns empty (no segment
+// to match); callers that need validation parse the result themselves.
+func appURLFromBase(baseURL string) string {
+	if strings.Contains(baseURL, ".api.") {
+		return strings.Replace(baseURL, ".api.", ".app.", 1)
+	}
+	return strings.Replace(baseURL, "//api.", "//app.", 1)
+}
+
 // buildAuthURL constructs the authentication URL for the app's CLI auth page.
 // The `path` argument selects between auth surfaces — `/auth/cli` for the
 // user-JWT browser flow, `/auth/dev-cli` for the developer-JWT browser flow.
 // Both surfaces share the same `redirect_uri` + `state` query-param contract.
 func buildAuthURL(baseURL, path, redirectURI, state string) string {
-	// Convert API base URL to app URL. Preprod carries a subdomain prefix
-	// (preprod.api.andamio.io) but production does not (api.andamio.io), so
-	// a plain ".api." replace no-ops on production and points the browser at
-	// the API gateway. Handle both host shapes.
-	// e.g. https://preprod.api.andamio.io -> https://preprod.app.andamio.io
-	//      https://api.andamio.io         -> https://app.andamio.io
-	appURL := baseURL
-	if strings.Contains(baseURL, ".api.") {
-		appURL = strings.Replace(baseURL, ".api.", ".app.", 1)
-	} else {
-		appURL = strings.Replace(baseURL, "//api.", "//app.", 1)
-	}
+	appURL := appURLFromBase(baseURL)
 
 	// Build the auth URL with query params
 	params := url.Values{}

--- a/cmd/andamio/user_test.go
+++ b/cmd/andamio/user_test.go
@@ -54,3 +54,24 @@ func TestBuildAuthURL(t *testing.T) {
 		})
 	}
 }
+
+func TestAppURLFromBase(t *testing.T) {
+	cases := []struct {
+		name    string
+		baseURL string
+		want    string
+	}{
+		{"production (no prefix)", "https://api.andamio.io", "https://app.andamio.io"},
+		{"preprod (subdomain prefix)", "https://preprod.api.andamio.io", "https://preprod.app.andamio.io"},
+		{"mainnet (subdomain prefix)", "https://mainnet.api.andamio.io", "https://mainnet.app.andamio.io"},
+		{"empty", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := appURLFromBase(tc.baseURL)
+			if got != tc.want {
+				t.Errorf("appURLFromBase(%q) = %q, want %q", tc.baseURL, got, tc.want)
+			}
+		})
+	}
+}

--- a/docs/plans/2026-06-05-001-fix-app-url-host-derivation-plan.md
+++ b/docs/plans/2026-06-05-001-fix-app-url-host-derivation-plan.md
@@ -1,0 +1,247 @@
+---
+title: "fix: Image upload 404 on mainnet — unify app-URL host derivation"
+status: completed
+date: 2026-06-05
+type: fix
+origin: "GitHub issue #117"
+depth: lightweight
+---
+
+# fix: Image upload 404 on mainnet — unify app-URL host derivation
+
+## Summary
+
+`course import` image uploads 404 on mainnet because `uploadImage` derives the
+app host with a single `.api.` → `.app.` string replace. The mainnet base URL
+`https://api.andamio.io` contains `//api.`, not `.api.`, so the replace no-ops
+and the CLI POSTs images to the API gateway (`api.andamio.io/api/upload` → 404)
+instead of the app (`app.andamio.io/api/upload`). Preprod works only because
+`preprod.api.andamio.io` happens to contain `.api.`.
+
+The correct dual-host logic already lives inline in `buildAuthURL`
+(`cmd/andamio/user.go:644-648`). Two other sites copy the broken single-replace:
+`uploadImage` (the reported bug) and `deriveAppOrigin` (`cmd/andamio/dev.go:51`,
+a latent mainnet bug in the dev browser-login Origin allow-list).
+
+This plan extracts a single shared `appURLFromBase(baseURL string) string` helper
+and routes all three call sites through it — fixing the reported 404, fixing the
+latent dev-login bug, and removing the duplicated derivation so the next mainnet
+host shape can't silently break one site but not another.
+
+---
+
+## Problem Frame
+
+App URLs are derived from the configured API base URL by swapping the `api`
+host segment for `app`. The hostname has two shapes in production use:
+
+| Base URL | Correct app URL | `.api.`→`.app.` (single) | `//api.`→`//app.` |
+|----------|-----------------|--------------------------|-------------------|
+| `https://preprod.api.andamio.io` | `https://preprod.app.andamio.io` | ✅ works | ✗ no-op |
+| `https://api.andamio.io` | `https://app.andamio.io` | ✗ **no-op (bug)** | ✅ works |
+
+No single replace covers both. `buildAuthURL` already branches correctly; the
+other two sites do not. The fix is to make one correct implementation and reuse
+it.
+
+**Affected sites (all in `cmd/andamio/`):**
+
+1. `course_import.go:1416` `uploadImage` — single replace → **mainnet 404** (issue #117).
+2. `dev.go:51` `deriveAppOrigin` — single replace → on mainnet returns
+   `https://api.andamio.io` as the allowed Origin, so the browser POST from
+   `https://app.andamio.io` fails the exact-string Origin allow-list and dev
+   browser-login breaks. Latent today (preprod-only testing has masked it).
+3. `user.go:644-648` `buildAuthURL` — already correct; refactor to call the
+   shared helper so there is exactly one implementation.
+
+---
+
+## Requirements
+
+- **R1.** `uploadImage` POSTs to the app host (not the API host) for both
+  preprod and mainnet base URLs. (issue #117 root requirement)
+- **R2.** `deriveAppOrigin` returns the app scheme+host for both base-URL shapes,
+  preserving its existing empty-string-on-unparseable contract.
+- **R3.** A single shared helper is the only place the `api`→`app` host swap
+  lives; all three call sites use it.
+- **R4.** `buildAuthURL` output is unchanged for both base-URL shapes (no
+  regression to the existing user/dev browser flows).
+
+---
+
+## Key Technical Decisions
+
+**KTD1 — One helper, dual-host logic.** Add
+`appURLFromBase(baseURL string) string` implementing the proven branch from
+`buildAuthURL`: if the URL contains `.api.`, replace `.api.` → `.app.`; else
+replace `//api.` → `//app.`. This is a pure string transform returning the full
+app base URL (scheme + host + any path), matching what `buildAuthURL` and
+`uploadImage` need. `deriveAppOrigin` keeps its own `url.Parse` + empty-string
+guard, but sources its `appURL` from this helper instead of the inline replace.
+
+**KTD2 — Home for the helper: `cmd/andamio/user.go`.** Place it adjacent to
+`buildAuthURL` (its origin logic) rather than introducing a new file. `user.go`,
+`dev.go`, and `course_import.go` are all `package main`, so the unexported
+helper is visible to all three with no new file or import churn. (A dedicated
+`apphost.go` is a reasonable alternative but adds a file for one small function;
+keep it co-located with the existing correct implementation.)
+
+**KTD3 — Preserve `deriveAppOrigin`'s safe-failure contract.** The helper does
+not parse or validate; `deriveAppOrigin` still does `url.Parse` and returns `""`
+on unparseable/empty input so the dev-login Origin allow-list fails closed.
+Empty `baseURL` must still flow to `""` — the helper returns `""` unchanged for
+`""` input (no `//api.` or `.api.` to match), and `deriveAppOrigin`'s existing
+`if baseURL == ""` guard stays.
+
+---
+
+## Implementation Units
+
+### U1. Add shared `appURLFromBase` helper and adopt it in `buildAuthURL`
+
+**Goal:** Single source of truth for the `api`→`app` host swap; prove parity
+with the existing correct behavior.
+
+**Requirements:** R3, R4
+
+**Dependencies:** none
+
+**Files:**
+- `cmd/andamio/user.go` — add `appURLFromBase`; replace the inline 4-line branch
+  in `buildAuthURL` (lines 644-648) with a call to it.
+- `cmd/andamio/user_test.go` — extend `TestBuildAuthURL` coverage / add
+  `TestAppURLFromBase`.
+
+**Approach:** Lift the exact branch from `buildAuthURL` into
+`appURLFromBase(baseURL string) string`. `buildAuthURL` then does
+`appURL := appURLFromBase(baseURL)`. No behavior change — `TestBuildAuthURL`
+(production + preprod cases at `user_test.go:45-46`) must still pass byte-for-byte.
+
+**Patterns to follow:** Existing dual-host branch and doc comment at
+`user.go:638-649`; table-driven test style in `TestBuildAuthURL`
+(`user_test.go:39-56`).
+
+**Test scenarios:**
+- `appURLFromBase("https://preprod.api.andamio.io")` → `https://preprod.app.andamio.io`.
+- `appURLFromBase("https://api.andamio.io")` → `https://app.andamio.io` (the bug case).
+- `appURLFromBase("https://mainnet.api.andamio.io")` → `https://mainnet.app.andamio.io`.
+- `appURLFromBase("")` → `""` (no panic, no partial transform).
+- Existing `TestBuildAuthURL` production + preprod cases still produce identical URLs (regression guard for R4).
+
+**Verification:** `go test ./cmd/andamio/ -run 'TestBuildAuthURL|TestAppURLFromBase'` passes; no diff in `buildAuthURL` output for known inputs.
+
+### U2. Route `uploadImage` through the helper (fixes the reported 404)
+
+**Goal:** `course import` uploads land on the app host for mainnet and preprod.
+
+**Requirements:** R1
+
+**Dependencies:** U1
+
+**Files:**
+- `cmd/andamio/course_import.go` — replace line 1416
+  (`appURL := strings.Replace(cfg.BaseURL, ".api.", ".app.", 1)`) with
+  `appURL := appURLFromBase(cfg.BaseURL)`.
+- `cmd/andamio/course_import_test.go` — add a focused test asserting the upload
+  URL derivation for mainnet vs preprod (see scenarios).
+
+**Approach:** One-line swap at the derivation; `uploadURL := appURL + "/api/upload"`
+is unchanged. If `strings` becomes unused in the file after the swap, drop the
+import (verify — the file almost certainly still uses `strings` elsewhere for
+MIME/extension handling, so likely no import change). Confirm whether
+`uploadImage`'s URL assembly is testable in isolation; if it is not currently
+factored for a unit test, assert on `appURLFromBase(cfg.BaseURL)+"/api/upload"`
+directly rather than refactoring `uploadImage`'s HTTP path in this fix.
+
+**Patterns to follow:** `uploadImage` signature and surrounding logic at
+`course_import.go:1414-1417`.
+
+**Test scenarios:**
+- Derived upload URL for `cfg.BaseURL = "https://api.andamio.io"` is
+  `https://app.andamio.io/api/upload` (mainnet — the reported 404 path). Covers issue #117.
+- Derived upload URL for `cfg.BaseURL = "https://preprod.api.andamio.io"` is
+  `https://preprod.app.andamio.io/api/upload` (preprod regression guard — must keep working).
+
+**Verification:** `go test ./cmd/andamio/` green; manual confidence check —
+trace that a mainnet config now targets `app.andamio.io`.
+
+### U3. Route `deriveAppOrigin` through the helper (fixes latent dev-login bug)
+
+**Goal:** Dev browser-login Origin allow-list is correct on mainnet; helper is
+the only derivation site.
+
+**Requirements:** R2, R3
+
+**Dependencies:** U1
+
+**Files:**
+- `cmd/andamio/dev.go` — replace line 51
+  (`appURL := strings.Replace(baseURL, ".api.", ".app.", 1)`) with
+  `appURL := appURLFromBase(baseURL)`. Keep the `if baseURL == ""` guard and the
+  `url.Parse` + empty-on-error return intact.
+- `cmd/andamio/dev_test.go` — add/extend `deriveAppOrigin` coverage for the
+  mainnet host shape and the empty/unparseable contract.
+
+**Approach:** Swap only the derivation line. The parse-and-validate guard around
+it is unchanged, so the fail-closed behavior (empty Origin ⇒ no browser POST
+allowed) is preserved. Update the doc comment at `dev.go:38-46` if it still
+claims a single `.api.` substitution.
+
+**Patterns to follow:** Existing `deriveAppOrigin` structure at `dev.go:47-57`;
+the test at `dev_test.go:~1353` that asserts the preprod-callback Origin.
+
+**Test scenarios:**
+- `deriveAppOrigin("https://api.andamio.io")` → `https://app.andamio.io`
+  (mainnet — the latent bug case; previously returned `https://api.andamio.io`).
+- `deriveAppOrigin("https://preprod.api.andamio.io")` → `https://preprod.app.andamio.io` (regression guard).
+- `deriveAppOrigin("")` → `""` (empty contract preserved).
+- `deriveAppOrigin("://bad")` or other unparseable → `""` (fail-closed contract preserved).
+
+**Verification:** `go test ./cmd/andamio/` green, including any existing dev
+browser-login Origin tests; the helper is now referenced by all three sites
+(`grep -n 'strings.Replace.*api' cmd/andamio/*.go` returns nothing).
+
+---
+
+## Scope Boundaries
+
+**In scope:** The three app-URL derivation sites in `cmd/andamio/`; one shared
+helper; tests proving mainnet + preprod for each.
+
+### Deferred to Follow-Up Work
+- **BaseURL validation** — issue #108 / `dev.go:44` already track validating
+  malformed base URLs at config time. This fix does not add validation; it only
+  makes derivation correct for the two real host shapes.
+- **Re-import of the 11 broken PBL images** (course `b7795c1b…a286f210`,
+  modules 099/100/102/202) — an operational follow-up once the binary ships, not
+  a code change. Re-running `course import` will pick up the images.
+
+**Out of scope:** Any change to the `/api/upload` endpoint, the upload payload,
+the CORS/PNA preflight logic itself, or the user-login GET wire format.
+
+---
+
+## Risks & Verification
+
+- **Risk: silently breaking the preprod path while fixing mainnet.** Mitigated
+  by keeping a preprod regression assertion in every unit's test scenarios — the
+  helper must satisfy both shapes, and the existing `TestBuildAuthURL` preprod
+  case is an additional guard.
+- **Risk: regressing `deriveAppOrigin`'s fail-closed contract.** Mitigated by
+  leaving the `url.Parse`/empty-return guard untouched and explicitly testing the
+  empty + unparseable cases (U3).
+- **End-to-end check (post-merge, optional):** with a mainnet config, run
+  `course import` on a module containing an `assets/*.png` reference and confirm
+  the upload returns a CDN URL rather than 404, and the lesson stores the CDN URL
+  rather than `assets/...`.
+
+---
+
+## Sources & Research
+
+- GitHub issue #117 — root-cause analysis, reproduction, suggested fix (shared
+  helper across the three sites).
+- `cmd/andamio/user.go:637-657` — the existing correct dual-host implementation
+  this plan generalizes.
+- `cmd/andamio/dev.go:47-57`, `cmd/andamio/course_import.go:1414-1417` — the two
+  single-replace copies being fixed.


### PR DESCRIPTION
## What & why

`andamio course import` / `import-all` image uploads **404 on mainnet**. Lesson text imports fine, but every image fails and the lesson is stored with an unresolved `assets/<file>` reference — broken images on-platform.

Root cause: `uploadImage` derived the app host from the API base URL with a single `.api.` → `.app.` string replace. The mainnet base URL `https://api.andamio.io` contains `//api.`, **not** `.api.`, so the replace no-ops and the CLI POSTs to `https://api.andamio.io/api/upload` (the API gateway → 404) instead of `https://app.andamio.io/api/upload`. Preprod was unaffected only because `preprod.api.andamio.io` happens to contain `.api.`.

`buildAuthURL` (`user.go`) already had correct dual-host logic from the 0.13.2 fix — but the logic was inline, and two other sites copied the broken single-replace. This PR extracts one shared `appURLFromBase` helper and routes all three sites through it.

## Changes

- **New `appURLFromBase(baseURL)` helper** (`user.go`) — single source of truth for the `api`→`app` host swap, handling both the preprod `.api.` subdomain form and the mainnet bare `//api.` form.
- **`uploadImage`** (`course_import.go`) — now uses the helper. **Fixes the reported #117 404.**
- **`deriveAppOrigin`** (`dev.go`) — carried the *same* latent single-replace bug: on mainnet it would misderive the dev-login Origin allow-list to the API host and reject the legitimate `app.` callback POST. Now uses the helper; the empty/unparseable **fail-closed** contract is preserved untouched.
- **`buildAuthURL`** (`user.go`) — refactored to call the helper; output is byte-for-byte unchanged (existing `TestBuildAuthURL` still passes).

## Testing

- `TestAppURLFromBase` — mainnet, preprod, `mainnet.api.` subdomain, and empty input.
- `TestUploadURLDerivation` — mainnet + preprod upload URLs (regression guard for #117).
- `TestDeriveAppOrigin` — mainnet, preprod, and both fail-closed paths (empty, unparseable).
- Existing `TestBuildAuthURL` unchanged and passing (no regression to auth flows).
- Full package suite green; `go vet` clean. No remaining single-`.api.`-replace sites outside the shared helper.

## Follow-up (out of scope)

- The 11 already-broken PBL images (course `b7795c1b…`, modules 099/100/102/202) need a **re-import** once a fixed binary ships — operational, not a code change.
- BaseURL validation at config time is tracked separately (#108).

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — this is a client-side CLI host-derivation fix with no server/runtime component. Validation is the test suite plus, optionally, a one-off `course import` of a module with an `assets/*.png` reference against a mainnet config: confirm the upload returns a CDN URL (not 404) and the lesson persists the CDN URL rather than `assets/...`.

Closes #117

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) · Opus 4.8 (1M context)
