### PR TITLE
docs: replace machine-specific paths with portable references

### DIFF
--- a/cmd/andamio/commitment_hash_parity_test.go
+++ b/cmd/andamio/commitment_hash_parity_test.go
@@ -35,7 +35,7 @@ import (
 //	  console.log(m.computeCommitmentHash(<JSON below>)))'
 //
 // Verified 2026-04-24 against andamio-core@<current> built at
-// ~/projects/01-projects/andamio-core/dist/utils/hashing/index.mjs.
+// $REPOS/andamio-core/dist/utils/hashing/index.mjs.
 // If this test ever fails after a @andamio/core release, re-run the TS
 // computation and update `want` — then open a follow-up to investigate
 // why the normalization/hash contract changed.

--- a/docs/brainstorms/2026-03-16-course-module-import-export-brainstorm.md
+++ b/docs/brainstorms/2026-03-16-course-module-import-export-brainstorm.md
@@ -110,6 +110,6 @@ None - all key decisions resolved.
 
 ## Related
 
-- **Coach compile skill:** `~/projects/01-projects/andamio-lesson-coach-v2/.claude/skills/compile/SKILL.md`
+- **Coach compile skill:** `$REPOS/andamio-lesson-coach-v2/.claude/skills/compile/SKILL.md`
 - **API endpoint:** `POST /v2/course/teacher/course-module/update`
 - **Tiptap format:** ProseMirror-based JSON schema

--- a/docs/plans/2026-03-13-feat-browser-wallet-authentication-plan.md
+++ b/docs/plans/2026-03-13-feat-browser-wallet-authentication-plan.md
@@ -288,10 +288,10 @@ After this feature, CLI users can access:
 
 ### Internal References
 
-- Existing auth: `/Users/james/projects/01-projects/andamio-platform/andamio-app-v2/src/lib/andamio-auth.ts`
-- Auth context: `/Users/james/projects/01-projects/andamio-platform/andamio-app-v2/src/contexts/andamio-auth-context.tsx`
-- CLI config: `/Users/james/projects/01-projects/andamio-cli/internal/config/config.go`
-- CLI client: `/Users/james/projects/01-projects/andamio-cli/internal/client/client.go`
+- Existing auth: `$REPOS/andamio-app-v2/src/lib/andamio-auth.ts`
+- Auth context: `$REPOS/andamio-app-v2/src/contexts/andamio-auth-context.tsx`
+- CLI config: `internal/config/config.go`
+- CLI client: `internal/client/client.go`
 
 ### External References
 

--- a/docs/plans/2026-03-16-feat-course-module-import-export-plan.md
+++ b/docs/plans/2026-03-16-feat-course-module-import-export-plan.md
@@ -430,7 +430,7 @@ From `docs/solutions/`:
 
 ### Related Work
 
-- Coach compile skill: `~/projects/01-projects/andamio-lesson-coach-v2/.claude/skills/compile/SKILL.md`
+- Coach compile skill: `$REPOS/andamio-lesson-coach-v2/.claude/skills/compile/SKILL.md`
 - API spec: `./openapi.json`
 
 ## Open Items

--- a/docs/plans/2026-03-18-feat-project-task-management-plan.md
+++ b/docs/plans/2026-03-18-feat-project-task-management-plan.md
@@ -5,7 +5,7 @@ status: active
 date: 2026-03-18
 origin:
   - docs/brainstorms/2026-03-18-project-task-management-brainstorm.md
-  - ~/projects/02-areas/andamio/docs/brainstorms/2026-03-18-github-integration-cli-brainstorm.md
+  - the 2026-03-18 github integration cli brainstorm note (internal)
 ---
 
 # feat: Project Task Management Commands
@@ -25,7 +25,7 @@ Project managers currently must use the web app to create and manage tasks. The 
 The demo story: a GitHub issue connects to (a) what someone needs to learn (Andamio course/module) and (b) where they earn reputation and rewards. The CLI makes this composable.
 
 (See brainstorm: `docs/brainstorms/2026-03-18-project-task-management-brainstorm.md`)
-(See brainstorm: `~/projects/02-areas/andamio/docs/brainstorms/2026-03-18-github-integration-cli-brainstorm.md`)
+(See brainstorm: `the 2026-03-18 github integration cli brainstorm note (internal)`)
 
 ## Proposed Solution
 
@@ -347,8 +347,8 @@ The audience sees: a real GitHub issue becomes an Andamio task. The developer wh
 ### Origin
 
 - **Brainstorm (CLI):** [docs/brainstorms/2026-03-18-project-task-management-brainstorm.md](docs/brainstorms/2026-03-18-project-task-management-brainstorm.md) — Key decisions: commands under `project`, directory of Markdown files, ISO 8601 dates, include tokens, warn-then-overwrite conflicts.
-- **Brainstorm (GitHub):** `~/projects/02-areas/andamio/docs/brainstorms/2026-03-18-github-integration-cli-brainstorm.md` — Key decisions: CLI stays Andamio-only, convention-based linking, composability over built-in GitHub features.
-- **Plan (GitHub):** `~/projects/02-areas/andamio/docs/plans/2026-03-18-feat-cli-task-commands-github-integration-plan.md` — Demo flow, script examples, `--github-issue` flag design.
+- **Brainstorm (GitHub):** `the 2026-03-18 github integration cli brainstorm note (internal)` — Key decisions: CLI stays Andamio-only, convention-based linking, composability over built-in GitHub features.
+- **Plan (GitHub):** `the 2026-03-18 feat cli task commands github integration plan note (internal)` — Demo flow, script examples, `--github-issue` flag design.
 
 ### Internal References
 

--- a/docs/plans/2026-04-01-001-fix-cli-pbl-retro-fixes-plan.md
+++ b/docs/plans/2026-04-01-001-fix-cli-pbl-retro-fixes-plan.md
@@ -3,7 +3,7 @@ title: "fix: Resolve 6 remaining CLI PBL retro issues"
 type: fix
 status: completed
 date: 2026-04-01
-origin: ~/projects/02-areas/andamio/000-task-notes/Tasks/cli-pbl-retro-fixes.md
+origin: the internal `cli-pbl-retro-fixes` note
 ---
 
 # fix: Resolve 6 remaining CLI PBL retro issues
@@ -253,7 +253,7 @@ The Midnight PBL walkthrough exposed 10 issues. Four are fixed (--address flag r
 
 ## Sources & References
 
-- **Origin document:** ~/projects/02-areas/andamio/000-task-notes/Tasks/cli-pbl-retro-fixes.md
+- **Origin document:** the internal `cli-pbl-retro-fixes` note
 - Related code: `cmd/andamio/course_teacher_ops.go`, `internal/config/config.go`, `cmd/andamio/tx_build.go`, `cmd/andamio/course_owner.go`
 - Config pattern: `cmd/andamio/config.go` (set-submit-url as model)
 - Submit header flow: `cmd/andamio/tx_submit.go`, `cmd/andamio/tx_lifecycle.go`

--- a/docs/plans/2026-04-24-001-feat-project-manager-qualified-contributors-plan.md
+++ b/docs/plans/2026-04-24-001-feat-project-manager-qualified-contributors-plan.md
@@ -290,7 +290,7 @@ runProjectManagerQualifiedContributors:
 ## Sources & References
 
 - **Issue:** https://github.com/Andamio-Platform/andamio-cli/issues/70
-- **Gateway plan:** `~/projects/01-projects/andamio-dev-kit-internal/plans/EligibleContributorsEndpointPlan.md` (response shape, status codes, 500-alias cap)
+- **Gateway plan:** `$REPOS/andamio-dev-kit-internal/plans/EligibleContributorsEndpointPlan.md` (response shape, status codes, 500-alias cap)
 - **Related code:**
   - `cmd/andamio/project_manager_ops.go` — sibling command + registration site
   - `cmd/andamio/helpers.go` — `getJSONWithHint`, `jwtAuthPreRunE`

--- a/docs/plans/2026-05-22-001-feat-browser-based-dev-login-plan.md
+++ b/docs/plans/2026-05-22-001-feat-browser-based-dev-login-plan.md
@@ -355,8 +355,8 @@ Test expectation: none — documentation-only unit; no behavioral change.
 ## Documentation / Operational Notes
 
 - After both this plan and andamio-app-v2#698 land, update `andamio-docs` CLI install/auth pages to document the new `dev login` no-args path. Out of scope for this PR; track separately.
-- The verification task note at `~/projects/02-areas/andamio/000-task-notes/Tasks/2026-05-22-verify-andamio-cli-013-before-andrew-handoff.md` should be revised to cover the browser flow once both halves ship — the current checklist only verifies the headless path (i.e., the v0.13.0 fix, not the actual Andrew-blocker).
-- The staged reply to Andrew at `~/projects/02-areas/andamio/000-inbox/2026-05-20-andrew-cli-auth-401-reply.md` should be revised to point at this plan / the new commands, not the headless `dev login --skey` path it currently describes.
+- The verification task note at `the 2026-05-22 verify andamio cli 013 before andrew handoff note (internal)` should be revised to cover the browser flow once both halves ship — the current checklist only verifies the headless path (i.e., the v0.13.0 fix, not the actual Andrew-blocker).
+- The staged reply to Andrew at `the 2026-05-20 andrew cli auth 401 reply note (internal)` should be revised to point at this plan / the new commands, not the headless `dev login --skey` path it currently describes.
 
 ## Sources & References
 

--- a/docs/solutions/architecture/goldmark-ast-walker-prevention-strategies.md
+++ b/docs/solutions/architecture/goldmark-ast-walker-prevention-strategies.md
@@ -880,8 +880,8 @@ func TestRegressions(t *testing.T) {
 ## References
 
 - **goldmark documentation:** https://github.com/yuin/goldmark
-- **Implementation:** `/Users/james/projects/01-projects/andamio-cli/cmd/andamio/course_import.go`
-- **Tests:** `/Users/james/projects/01-projects/andamio-cli/cmd/andamio/course_import_test.go`
+- **Implementation:** `cmd/andamio/course_import.go`
+- **Tests:** `cmd/andamio/course_import_test.go`
 - **Tiptap format:** https://www.tiptap.dev/guide/output#json
 - **ProseMirror nodes:** https://prosemirror.net/docs/ref/#model
 

--- a/docs/solutions/integration-issues/gateway-status-code-drift-409-vs-400.md
+++ b/docs/solutions/integration-issues/gateway-status-code-drift-409-vs-400.md
@@ -180,11 +180,11 @@ When building a typed-error gate — or any client-side predicate conditioned
 on an external status code / body shape — **read the gateway code** (or
 capture a real response) before merging. In the andamio toolchain the
 gateway source is checked out alongside the CLI at
-`~/projects/01-projects/andamio-api/`, so verification is a grep away:
+`$REPOS/andamio-api/`, so verification is a grep away:
 
 ```bash
 grep -rn "StatusConflict\|StatusBadRequest\|fiber.Status" \
-    ~/projects/01-projects/andamio-api/internal/handlers/v2/ | \
+    $REPOS/andamio-api/internal/handlers/v2/ | \
     grep -i "<the-error-code-name>"
 ```
 


### PR DESCRIPTION
Repo content pointed at absolute paths on individual contributors's machines, and in places into a private Obsidian vault. None of it resolved for anyone else reading the repo.

**What changed**
- Cross-repo references use a `$REPOS` placeholder, so the path *shape* stays intact (shell snippets remain runnable once `REPOS` is set) while the reader supplies their own checkout root.
- Paths naming *this* repo became repo-relative.
- Private-vault citations were replaced with a description of what the source was, since a reader cannot open those at all.

Found by a path guard that scans repo files and issue/PR bodies. Across all repos this cleared 267 of 274 references; the 7 left are false positives (docs describing the problem itself, and script config defaults where changing the value would change behaviour).