### PR TITLE
docs: 1.0 requires Andamio API 2.5 or later, and mainnet is not there yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ The format follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/
 
 If you own, teach or manage on Andamio, **your workflows are unchanged.** Everything you do today — creating courses and projects, importing and publishing module content, minting tasks, reviewing submissions, signing transactions with a local `.skey` — works exactly as it did in 0.13, and this release adds to it.
 
+### Requires Andamio API 2.5 or later
+
+**1.0 is supported against Andamio API 2.5 and later only.** It was built and verified against 2.5, which carries a contract naming change and a new pagination convention; it has never been tested against the 2.4 line. Running 1.0 against a 2.4 gateway is unsupported, and the failures would not be limited to the new commands.
+
+**At release, this means preprod only.** Mainnet has not yet cut over to 2.5 — the pre-cutover work is tracked in `andamio-ops#189` — so **if you teach or manage on mainnet, stay on 0.13.x until that lands.** We are stating this plainly rather than leaving it to be discovered, because 1.0's headline addition is the Teacher assessment surface and mainnet Teachers are exactly the people who cannot use it yet.
+
+Supporting two gateway contracts from one CLI was the alternative, and we chose not to: it would mean every command carrying two code paths, with the version-detection logic itself untested against the older one. Declaring the requirement is the honest statement of what was actually verified.
+
 What 1.0 adds is a designed automation surface for assessment. Our own tooling has been driving the CLI with `--output json` for months; this release makes that a supported path rather than a happy accident.
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ Learners and contributors use the [Andamio app](https://app.andamio.io), which s
 
 The CLI is built to be driven by programs as well as people. Every list and get command takes `--output json`; progress goes to stderr and data to stdout; nothing reads stdin or prompts. See [Scripting](#scripting) below.
 
+## Which version you need
+
+> **1.0 requires Andamio API 2.5 or later.** It was built and verified against 2.5 and has never been tested against the 2.4 line.
+>
+> **Mainnet has not cut over to 2.5 yet** (tracked in `andamio-ops#189`). Until it does, use **1.0 on preprod** and **stay on 0.13.x for mainnet**. Check the [CHANGELOG](CHANGELOG.md#requires-andamio-api-25-or-later) before upgrading a mainnet workflow.
+
 ## Installation
 
 ### Homebrew (macOS)


### PR DESCRIPTION
Stacked on #130 — targets `feat/cli-1-0-release-scope`, not `main`.

## What this adds

The 1.0 CHANGELOG entry opens with *"If you own, teach or manage on Andamio, **your workflows are unchanged.**"* For anyone working on mainnet that is not true yet, and nothing in the release notes said so.

1.0 was built and verified against Andamio API 2.5 — its preprod dry run passed against 2.5.0 on 2026-07-31 — and has never been tested against the 2.4 line. So the supported statement is a **declared requirement of 2.5 or later**, which is the honest description of what was actually verified, and it avoids the CLI carrying two gateway contracts.

The consequence lands on a specific group, so this names them rather than leaving it to be inferred: **mainnet Teachers cannot use 1.0 until the cutover**, and the Teacher assessment surface is 1.0's headline addition.

Two placements, both where a person would actually look:
- **CHANGELOG** — a `### Requires Andamio API 2.5 or later` section directly under the 1.0 heading, before the "what's unchanged" reassurance can be misread.
- **README** — a short block before the install instructions, since the decision to install is made there.

It also records the rejected alternative (support 2.4 and 2.5 from one CLI) so that trade-off does not get re-argued later.

## Verification, and its limits

- **Verified:** the mainnet cutover has not happened. `andamio-ops#189`'s pre-cutover checklist is open and unchecked as of 2026-07-30.
- **Not verified by me:** the exact version strings each gateway serves. `/api/v2` is behind auth on both hosts, and an unauthenticated probe cannot discriminate — a nonsense path returns the same `401` as a real one, so route- and version-detection from outside is not possible. The text therefore claims "has not cut over to 2.5", which `ops#189` supports, and avoids asserting specific deployed version numbers.

Docs only — no code, no behavior change.

**Note on merge order:** if #130 merges with `--delete-branch`, this PR closes unrecoverably. Retarget it to `main` first, or merge this one into #130 beforehand.