### PR TITLE
docs: correct CLAUDE.md's testing claim, add CONTRIBUTING.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,28 @@ Install to PATH:
 cp andamio /usr/local/bin/andamio
 ```
 
-No linter configuration. Tests exist for export/import conversion functions.
+No linter configuration.
+
+## Testing
+
+```bash
+go test ./...          # full suite
+go test ./cmd/andamio  # command layer, where the contract guards live
+```
+
+**The test suite is the contract.** There are ~375 test functions. Most of the guarantees described in this file are enforced by a specific test, not by convention — before changing behavior in these areas, read the guard first:
+
+| Invariant | Guarded by |
+|-----------|-----------|
+| Exit-code / `kind` mapping (see [Failure Contract](#failure-contract)) | `cmd/andamio/exitcode_test.go` |
+| Retired 1.0 commands: exit 4, hidden, message text, every invocation shape | `cmd/andamio/retired_test.go` |
+| No source file calls a retired route | `TestNoSourceFileCallsARetiredRoute` in `retired_test.go` |
+| Unknown command exits non-zero with clean stdout | `cmd/andamio/unknown_test.go` |
+| Local JWT expiry handling at all four enforcement points | `cmd/andamio/expired_jwt_test.go` |
+| Export/import Markdown ↔ Tiptap conversion | `course_export_test.go`, `course_import_test.go` |
+| Commitment hash parity with the protocol | `commitment_hash_parity_test.go` |
+
+If you are adding a rule that must not regress, add a case to the relevant file above rather than building a separate mechanism.
 
 ## Release
 
@@ -100,7 +121,15 @@ Two properties are load-bearing and easy to break:
 
 `TestNoSourceFileCallsARetiredRoute` walks the AST of every non-test source file and fails on a string literal referencing `/course/student/` or `/project/contributor/`. It inspects literals rather than raw text so comments explaining a removal stay legal.
 
+**Enforcement lives in `cmd/andamio/retired_test.go`** — all of the above, including the two load-bearing properties, plus every retired path in every invocation shape. Both properties are silent failures if broken: nothing else in the build notices. Note that the retired stubs are `Hidden: true`, so any tooling built on `cobra/doc.GenMarkdownTree` cannot see them and cannot guard them.
+
+### 1.0 release status
+
+**1.0 is merged to `main` but not tagged.** The latest release is `v0.13.3`, which still ships the learner/contributor surface. 1.0 declares a hard requirement on **Andamio API 2.5 or later** and mainnet has not cut over (`andamio-ops#189`), so the tag is gated on that cutover. See the `## [1.0.0]` CHANGELOG entry and README for the supported-version statement. Two consequences worth holding onto: the published contract today is 0.13.x, not what is on `main`; and because 2.5 carries a contract naming change, the cutover is the moment this CLI meets renamed gateway fields (see `todos/031`).
+
 ## Failure Contract
+
+*Enforced by `cmd/andamio/exitcode_test.go`. The `kind` strings below are a public API — scripts branch on them. Changing one is a breaking change and will fail that test.*
 
 Every failure carries an exit code **and**, under `--output json`, a `kind` field. Both derive from `apierr.Kind`, the single mapper, so they cannot drift apart. `Kind` unwraps through `fmt.Errorf("%w")` and `ReportedError` — the command layer wraps liberally, and a mapper that only inspected the top-level error would classify nearly everything as generic.
 
@@ -217,6 +246,20 @@ Exit codes 0–3 predate 1.0 and are fixed. `conflict` moved from 1 to 6 in 1.0.
 **Inspection is a request-echo, not a CBOR decode.** `AssessmentBuildEnvelope` carries the decision set alongside the unsigned transaction so a reviewer sees both from one command, instead of trusting an agent's separate prose summary of what opaque CBOR encodes. It proves what was *asked for*, not what the gateway *built*. Decoding the transaction needs Plutus datum interpretation and is out of scope for 1.0 — the limitation is stated in the command help and the type doc, not papered over.
 
 Duplicate aliases are **rejected**, not last-wins: two conflicting outcomes for one learner means the caller lost track of its own decision set, and silently picking one would put a credential decision on-chain that nobody made.
+
+### manager — Project manager role group
+| Command | Endpoint | Auth | Description |
+|---------|----------|------|-------------|
+| `manager projects` | `/api/v2/project/manager/projects/list` | jwt | List projects where you are a manager |
+
+**Top-level `manager` is deliberate, not a stray.** It parallels top-level `teacher`: both answer "what do I hold this role on?" and are the entry point to a role's workflow. The nested `project manager *` subgroup (commitments, qualified-contributors) operates *within* one project you already know the ID of. `cmd/andamio/project_manager_ops.go` records the decision — "the existing top-level `manager` command stays as-is" — so don't consolidate them without revisiting that. There is no `project manager list`; `manager projects` is the only way to discover the projects you manage.
+
+### token — Native asset token registry
+| Command | Endpoint | Auth | Description |
+|---------|----------|------|-------------|
+| `token list` | `/api/v2/token/user/tokens/list` | either | List registered tokens available as task rewards |
+
+Supplies the `policy_id` / `asset_name` values for `project task create --token "<policy_id>,<asset_name>,<quantity>"`. Text output is a ticker/policy/asset/decimals table; `--output json` passes the gateway envelope through. Tolerates both `{data: [...]}` and a bare array from the gateway.
 
 ### tx — Transactions
 | Command | Endpoint | Auth | Description |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+# Contributing to Andamio CLI
+
+## Before you start
+
+Read [`CLAUDE.md`](CLAUDE.md). It is the architecture document for this repo and is kept current — the command reference, the failure contract, the auth flows, and the export/import invariants all live there.
+
+Two sections are worth reading before writing any code: **The 1.0 Surface** (what was removed and why the stubs must stay hidden) and **Failure Contract** (exit codes and `kind` strings, which are a public API).
+
+## How change lands
+
+Branch → commit → push → open a PR against `main`. Never push directly to `main`.
+
+Nothing is merged by the author. CI must be green.
+
+## What CI runs
+
+`.github/workflows/ci.yml` runs on every PR: `gofmt`, `go vet ./...`, `go build ./...`, and `go test -count=1 ./...`.
+
+Run all four locally before pushing:
+
+```bash
+go vet ./... && go build ./... && go test -count=1 ./...
+gofmt -l $(git diff --name-only --diff-filter=d origin/main HEAD -- '*.go')
+```
+
+**Check `gofmt` only on the files your branch touches, as CI does.** The tree carries pre-existing alignment drift from a toolchain bump, so `gofmt -l .` across the whole repo prints ~9 files that have nothing to do with your change. `ci.yml` scopes the check to your diff for exactly this reason.
+
+`gofmt -l` printing a filename is a failure even though it exits 0 — so it goes on its own line above, not in an `&&` chain where a non-empty result would be silently swallowed.
+
+## The test suite is the contract
+
+**~375 test functions, and most of this repo's documented guarantees are enforced by a specific one.** Before changing behavior in a guarded area, read the guard. `CLAUDE.md`'s Testing section maps invariants to files; the load-bearing ones are:
+
+- `cmd/andamio/exitcode_test.go` — the exit-code / `kind` table
+- `cmd/andamio/retired_test.go` — retired 1.0 commands (exit 4, hidden, message text, every invocation shape)
+- `cmd/andamio/unknown_test.go` — unknown commands exit non-zero with clean stdout
+- `cmd/andamio/expired_jwt_test.go` — local JWT expiry handling
+
+**If you are adding a rule that must not regress, add a case to the relevant file above.** Prefer extending the existing suite over introducing a parallel mechanism — a check that lives outside `go test` will not be run by contributors before pushing, and tends to be blind to things the suite already covers (hidden commands, anything under `internal/`).
+
+Golden-file style tests belong in the same package as what they cover, with an `-update` flag to regenerate.
+
+## CHANGELOG policy
+
+`CHANGELOG.md` is the source of truth for user-facing release notes — `.github/workflows/release.yml` extracts the `## [VERSION]` section verbatim into the GitHub release body.
+
+**It is not a per-PR requirement.** Add an entry when your change is user-visible: a new or removed command, a flag change, a change to `--output json` shape, a behavior change, an exit-code change. Put it under `## [Unreleased]`.
+
+Do **not** add an entry for docs, CI, refactors with no behavior change, test-only changes, or `todos/` notes. A changelog padded with those is worse than one with gaps.
+
+At release, a maintainer moves `## [Unreleased]` content under a new version heading. `scripts/release.sh` verifies the section is *extractable*, not merely that the heading exists.
+
+## Adding a command
+
+`CLAUDE.md` has the pattern under **Adding Endpoints**. Beyond that:
+
+- **Every command must work without a TTY.** Never read from stdin in a handler. See the Composability Rules in `CLAUDE.md` — they are not optional, and `--output json` is the scripting surface that agents and pipes consume.
+- **Data to stdout, progress to stderr.** Gate progress messages on `output.GetFormat()` so `--output json` stays parseable.
+- **Required arguments are required.** Use `cobra.ExactArgs(N)` and `MarkFlagRequired`. If an argument is missing, return an error that says how to discover valid values — no interactive pickers.
+- **Update the command reference in `CLAUDE.md`** in the same PR. It is meant to be complete; drift there is how contributors end up building on wrong assumptions.
+
+**Repo tooling does not belong on `rootCmd`.** Anything that only makes sense from the repo root — code generation, snapshot regeneration, CI checks — belongs in `go test`, `scripts/`, or a separate `tools/` main. Commands registered on `rootCmd` ship in the binary users install, and `Hidden: true` does not make them unreachable.
+
+## `todos/`
+
+Findings that are real but not being fixed now go in `todos/` as `NNN-<status>-<priority>-<slug>.md` with YAML frontmatter (`status`, `priority`, `issue_id`, `tags`, `dependencies`). Take the next free number. Cross-reference related todos by filename.
+
+`docs/solutions/` is the counterpart for problems already solved — a documented solution, not an open item.
+
+## API version coupling
+
+**1.0 requires Andamio API 2.5 or later**, by deliberate choice — supporting 2.4 and 2.5 from one binary was considered and rejected. See the `## [1.0.0]` CHANGELOG entry.
+
+The CLI decodes most gateway responses into `map[string]interface{}`, so a renamed upstream field usually produces a *wrong* result rather than an error. If you are touching response handling, prefer a typed struct (`devKeyListItem` in `cmd/andamio/dev_keys.go` is the reference pattern) and check that a missing key fails loudly. Context and known instances: `todos/031-pending-p3-no-typed-api-contract-coupling.md`.


### PR DESCRIPTION
Follow-up to the review on #141. Docs only — no code, no behavior change.

## Why

`CLAUDE.md:23` said:

> No linter configuration. Tests exist for export/import conversion functions.

The repo has **~375 test functions**, including ~1,600 lines that exist specifically to guard the 1.0 contract (`exitcode_test.go`, `retired_test.go`, `unknown_test.go`, `expired_jwt_test.go`). That line was probably true a long time ago.

A contributor reading it would reasonably conclude there is no contract enforcement in this repo. In #141 one did, and built a parallel snapshot-based mechanism from scratch — which then turned out to be blind to the retired-command surface (hidden commands are invisible to `cobra/doc`) and to everything under `internal/` (where most of the `--output json` envelope is produced). The doc caused the work.

## What changed

**`CLAUDE.md`**

- Replaced the wrong line with a **Testing** section mapping each documented invariant to the test that enforces it, and saying plainly that the suite *is* the contract.
- **The 1.0 Surface** now points at `retired_test.go` and notes that the stubs are `Hidden: true`, so `cobra/doc.GenMarkdownTree`-based tooling cannot see or guard them. That property is load-bearing and was undiscoverable.
- **Failure Contract** now states that the `kind` strings are a public API enforced by `exitcode_test.go`.
- New **1.0 release status** subsection: 1.0 is merged to `main` but untagged, gated on the mainnet cutover to Andamio API 2.5 (`andamio-ops#189`). The published contract today is 0.13.x, not what is on `main` — which matters to anyone reasoning about breaking changes.
- Documented **`manager`** and **`token`**, which were missing from the section CLAUDE.md calls the *Complete Command Reference*. Both are live, unhidden, top-level commands. Top-level `manager` parallels top-level `teacher` by decision — `project_manager_ops.go` records it — so the entry says so rather than leaving it looking accidental.

**`CONTRIBUTING.md`** (new) — did not exist, so several things were nowhere written down:

- How change lands, and the exact CI commands.
- That `gofmt` is scoped to changed files, and why (pre-existing toolchain drift means `gofmt -l .` prints ~9 unrelated files).
- **CHANGELOG is per-release, not per-PR** — with an explicit list of what does and does not warrant an entry.
- The test suite as the place to add regression guards, rather than a parallel mechanism.
- **Repo tooling does not belong on `rootCmd`** — commands registered there ship in the binary users install, and `Hidden: true` does not make them unreachable.
- The `todos/` convention and the API-version coupling caveat, pointing at `todos/031`.

## Verification

- `go build ./...`, `go vet ./...` pass.
- No `.go` files touched, so CI's diff-scoped `gofmt` step has nothing to check.
- Every factual claim checked against the tree: test counts, file names, `TestNoSourceFileCallsARetiredRoute`'s location, `ci.yml`'s actual commands, the endpoints for `manager projects` and `token list`, and the absence of a `v1.0.0` tag.