### PR TITLE
fix(changelog): restore the 1.0.0 heading, and guard the case that hid its loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,19 +6,7 @@ The format follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/
 
 ## [Unreleased]
 
-### Fixed
-
-- **`course owner teachers` works again (#140).** The command was POSTing to `/api/v2/course/owner/teachers/update`, a route `andamio-api#689` removed on 2026-07-28 — so it was broken against API 2.5, the only version 1.0 supports. Since Owner teacher management is in 1.0's declared scope, this was a release blocker.
-
-  It now runs the canonical transaction path (`POST /v2/tx/course/owner/teachers/manage`, tx type `teachers_update`) through the same build→sign→submit→register→poll lifecycle as `tx run`.
-
-### Changed
-
-- **BREAKING: `course owner teachers` now requires `--skey`, `--alias`, and a configured submit URL.** Appointing a teacher is an on-chain action, not a database write, and the retired route was a DB proxy that wrote the role with no originating transaction. The command therefore signs and submits like every other state-changing operation.
-
-  **If you script this command, add `--alias <your-owner-alias>` and `--skey <path>`, and make sure `andamio config set-submit-url` has been run.** `--add` and `--remove` keep their names and behavior. New: `--no-wait`, `--timeout`, `--submit-url`, `--submit-header`, `--metadata`, matching `tx run`.
-
-  Under `--output json` the command now emits the transaction `RunResult` envelope (`state`, `tx_hash`, and step progress) rather than the gateway's former write response. Text mode still ends with `Teachers updated.`
+## [1.0.0] - 2026-07-27
 
 **Andamio CLI 1.0 is a developer tool for the people who author work and assess it: course Owners and Teachers, and project Managers.**
 
@@ -70,6 +58,12 @@ What 1.0 adds is a designed automation surface for assessment. Our own tooling h
 
 - **BREAKING: conflict errors now exit 6 instead of 1.** A 409 was already a typed error internally but shared exit 1 with every unclassified failure, so a script could not tell a genuine conflict from an unexpected error. **If you branch on exit 1 for conflicts, update to 6.** This is the only exit-code change to an existing path; codes 0–3 are unchanged and remain fixed.
 
+- **BREAKING: `course owner teachers` now requires `--skey`, `--alias`, and a configured submit URL.** Appointing a teacher is an on-chain action, not a database write, and the route this command used was a DB proxy that wrote the role with no originating transaction. It now signs and submits like every other state-changing operation.
+
+  **If you script this command, add `--alias <your-owner-alias>` and `--skey <path>`, and make sure `andamio config set-submit-url` has been run.** `--add` and `--remove` keep their names and behavior. New pass-throughs: `--no-wait`, `--timeout`, `--submit-url`, `--submit-header`, `--metadata`, matching `tx run`.
+
+  Under `--output json` the command now emits the transaction `RunResult` envelope (`state`, `tx_hash`, and step progress) rather than the gateway's former write response. Text mode still ends with `Teachers updated.`
+
 - `andamio --help` describes a three-role tool rather than "query courses, credentials, and more". README and the in-repo guides match.
 
 ### Fixed
@@ -81,6 +75,8 @@ What 1.0 adds is a designed automation surface for assessment. Our own tooling h
 - `andamio teacher assignments get` returned an untyped error (exit 1) when a course had no commitments, while the otherwise-identical "no matching student" branch a few lines later correctly exited 2. Both now exit 2 with `kind: not_found`, so "this course has nothing" is no longer indistinguishable from a server failure.
 
 - The assess-transaction example in `docs/andamio-cli-context.md` documented fields that do not exist (`assessments`, `student_alias`, `result: "pass"`). The real shape is `assignment_decisions`, `alias`, `outcome: "accept"`. An agent following the old example would have built a request the API rejects. `teacher assessment build` now owns that payload shape so it cannot be got wrong by hand.
+
+- **`course owner teachers` works again** (#140). The command POSTed to `/api/v2/course/owner/teachers/update`, a route `andamio-api#689` removed on 2026-07-28 — so it was broken against API 2.5, the only version 1.0 supports, with no fallback. Since Owner teacher management is in 1.0's declared scope, this was a release blocker rather than a latent issue. It now runs the canonical transaction path (`POST /v2/tx/course/owner/teachers/manage`, tx type `teachers_update`) through the same build→sign→submit→register→poll lifecycle as `tx run`. See the BREAKING note under **Changed** for the new required flags.
 
 ## [0.13.3] - 2026-06-05
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -87,7 +87,30 @@ if grep -qF "## [${VERSION}]" CHANGELOG.md; then
     echo "    The release workflow publishes this section as the release body."
     exit 1
   fi
+  # A populated '## [VERSION]' heading is still not enough. When the versioned
+  # heading is written *before* the release ships — as '## [1.0.0]' was, months
+  # ahead of its tag — every PR merged in the meantime lands its notes under
+  # '## [Unreleased]'. changelog-section.sh extracts only the versioned section,
+  # so those notes are dropped from the published body without a word.
+  #
+  # The equivalent guard below only runs when the heading is *absent*, which is
+  # the "forgot to promote" case. This is the mirror: heading present, entries
+  # stranded above it. Same outcome — release notes that omit a breaking change.
+  STRANDED=$(awk '/^## \[Unreleased\]/{flag=1; next} /^## \[/{flag=0} flag' CHANGELOG.md)
+  if echo "$STRANDED" | grep -qE '^[[:space:]]*[-*]'; then
+    echo "  ✗ '## [Unreleased]' has entries and '## [$VERSION]' already exists"
+    echo "    Only the '## [$VERSION]' section is published as the release body,"
+    echo "    so these entries would ship silently omitted:"
+    echo ""
+    echo "$STRANDED" | grep -E '^[[:space:]]*[-*]' | cut -c1-96 | sed 's/^/      /'
+    echo ""
+    echo "    Fold them into '## [$VERSION]' (or promote them to their own"
+    echo "    version) before tagging. No bypass prompt — a dropped breaking"
+    echo "    change is exactly what these notes exist to prevent."
+    exit 1
+  fi
   echo "  ✓ CHANGELOG entry found for $VERSION ($(printf '%s' "$NOTES" | wc -l | tr -d ' ') lines of release notes)"
+  echo "  ✓ '## [Unreleased]' is empty — nothing stranded above the release"
 else
   # Extract the body of [Unreleased] (lines after the heading, stopping at the next
   # '## [' heading). Match a non-whitespace bullet ('-' or '*') to determine "has content".


### PR DESCRIPTION
Regression from #144, plus the preflight gap that let it through unnoticed.

## What broke

#144's CHANGELOG edit replaced the block spanning `## [Unreleased]` through `## [1.0.0] - 2026-07-27` and **did not restore the versioned heading.** Every line of 1.0's release notes survived, but they fell under `## [Unreleased]`, so on `main` today:

```
$ grep -n '^## \[' CHANGELOG.md
7:## [Unreleased]
85:## [0.13.3] - 2026-06-05      ← no 1.0.0 section at all

$ ./scripts/changelog-section.sh 1.0.0
changelog-section: no content found under '## [1.0.0]' in CHANGELOG.md
```

My error, caught while verifying something else in the same file.

## The fix

Restore the heading, and **fold #144's two entries into 1.0's own `Changed` and `Fixed` subsections** rather than leaving them stranded above it. 1.0 has not tagged, so these are not post-release notes — `course owner teachers` genuinely changes shape *in* 1.0, and mainnet Owners reading the release notes are exactly the people who need to see that it now requires `--skey` and `--alias`.

Apart from those two additions, `CHANGELOG.md` is byte-identical to its pre-#144 state. Verified by diffing against `13e1172`.

## The guard, which is the more useful half

`release.sh`'s preflight could not have caught this — and would not catch the likelier version either.

Its `'[Unreleased]' has entries` check lives **only in the branch where the versioned heading is absent** (`release.sh:91`), the "maintainer accumulated entries and forgot to promote" case. When the heading is written months *before* the tag — as `## [1.0.0] - 2026-07-27` was — the mirror case applies:

- heading present and populated → preflight prints ✓ and proceeds
- `changelog-section.sh` extracts **only** the versioned section
- anything merged under `[Unreleased]` in the meantime is dropped from the published body, silently

That is not hypothetical. Between now and the 1.0 tag, every merged PR lands its notes under `[Unreleased]`, and the next `--output json` or exit-code change would ship with its breaking-change callout missing.

This adds the mirror guard to the heading-exists branch. It prints the stranded bullets so the remedy is obvious, and has no bypass prompt — matching the existing guard's reasoning that a dropped breaking change is precisely what these notes exist to prevent.

## Verification

- [x] `./scripts/changelog-section.sh 1.0.0` extracts 69 lines and contains both `course owner teachers` entries
- [x] `[Unreleased]` is empty; headings read `[Unreleased]` → `[1.0.0]` → `[0.13.3]`
- [x] `CHANGELOG.md` diffs clean against `13e1172` except the two intended additions
- [x] Guard **fires** on a stranded entry and prints it; **stays silent** on the clean tree — both tested directly
- [x] `bash -n scripts/release.sh`, `go build ./...`
- [ ] Not tested: a full `release.sh` run. The earlier preflight steps require a real tag operation, so only the changelog logic was exercised in isolation.